### PR TITLE
feat: add basic Grafana dashboard configmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,38 @@ All project documentation is organized in the `docs/` folder:
 - **[docs/DEVELOPMENT_IDENTITY_HEADER.md](docs/DEVELOPMENT_IDENTITY_HEADER.md)** - Identity header generation for local development
 - **[docs/AI_AGENT_CONTEXT.md](docs/AI_AGENT_CONTEXT.md)** - Guidelines for AI-assisted development
 
+## Grafana Dashboard
+
+A basic Grafana dashboard is defined in `dashboards/grafana-dashboard-insights-widget-layout-backend-general.configmap.yml`. It includes latency and 2xx response rate panels.
+
+To preview locally:
+
+```bash
+# Start Grafana
+docker run -d -p 3000:3000 --name grafana-local grafana/grafana
+
+# Extract and import the dashboard
+python3 -c "
+import yaml, json
+with open('dashboards/grafana-dashboard-insights-widget-layout-backend-general.configmap.yml') as f:
+    cm = yaml.safe_load(f)
+dashboard_json = json.loads(cm['data']['general.json'])
+print(json.dumps({'dashboard': dashboard_json, 'overwrite': True}))
+" > /tmp/grafana-dashboard-import.json
+
+curl -s -X POST http://admin:admin@localhost:3000/api/dashboards/db \
+  -H "Content-Type: application/json" \
+  -d @/tmp/grafana-dashboard-import.json
+
+# Open http://localhost:3000/d/widget-layout-backend-general/widget-layout-backend
+# Login: admin / admin
+
+# Cleanup
+docker stop grafana-local && docker rm grafana-local
+```
+
+> **Note:** The local Grafana instance has no Prometheus datasource, so panels will show "No data". This is expected — the purpose is to verify dashboard structure and layout, not live metrics.
+
 ## More Information
 
 - See **[docs/API.md](docs/API.md)** for complete API documentation with endpoints, examples, and schemas.

--- a/dashboards/grafana-dashboard-insights-widget-layout-backend-general.configmap.yml
+++ b/dashboards/grafana-dashboard-insights-widget-layout-backend-general.configmap.yml
@@ -1,0 +1,216 @@
+---
+apiVersion: v1
+data:
+  general.json: |-
+    {
+      "annotations": {
+        "list": [
+          {
+            "builtIn": 1,
+            "datasource": {
+              "type": "datasource",
+              "uid": "grafana"
+            },
+            "enable": true,
+            "hide": true,
+            "iconColor": "rgba(0, 211, 255, 1)",
+            "name": "Annotations & Alerts",
+            "target": {
+              "limit": 100,
+              "matchAny": false,
+              "tags": [],
+              "type": "dashboard"
+            },
+            "type": "dashboard"
+          }
+        ]
+      },
+      "editable": true,
+      "fiscalYearStartMonth": 0,
+      "graphTooltip": 0,
+      "links": [],
+      "liveNow": false,
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "decimals": 2,
+              "mappings": [],
+              "max": 1,
+              "min": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 90
+                  }
+                ]
+              },
+              "unit": "percentunit"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 0
+          },
+          "id": 1,
+          "options": {
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "mean"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showThresholdLabels": false,
+            "showThresholdMarkers": true,
+            "text": {}
+          },
+          "pluginVersion": "9.0.3",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "exemplar": true,
+              "expr": "sum(rate(api_3scale_gateway_api_time_bucket{le=\"2000.0\", exported_service=\"widget-layout-backend\"}[24h])) / sum(rate(api_3scale_gateway_api_time_bucket{le=\"+Inf\", exported_service=\"widget-layout-backend\"}[24h]))",
+              "interval": "",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "Latency <= 2000ms",
+          "type": "gauge"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "decimals": 2,
+              "mappings": [],
+              "max": 1,
+              "min": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 90
+                  }
+                ]
+              },
+              "unit": "percentunit"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 8
+          },
+          "id": 2,
+          "options": {
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "mean"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showThresholdLabels": false,
+            "showThresholdMarkers": true,
+            "text": {}
+          },
+          "pluginVersion": "9.0.3",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "exemplar": false,
+              "expr": "round(sum(rate(api_3scale_gateway_api_status{exported_service=\"widget-layout-backend\", status=~\"[234]xx\"}[24h])) \n    /\n    sum(rate(api_3scale_gateway_api_status{exported_service=\"widget-layout-backend\"}[24h])), 0.0001)",
+              "instant": false,
+              "interval": "",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "2xx responses",
+          "type": "gauge"
+        }
+      ],
+      "refresh": "",
+      "schemaVersion": 36,
+      "style": "dark",
+      "tags": [],
+      "templating": {
+        "list": [
+          {
+            "current": {
+              "selected": false,
+              "text": "crcs02ue1-prometheus",
+              "value": "crcs02ue1-prometheus"
+            },
+            "hide": 0,
+            "includeAll": false,
+            "label": "Datasource",
+            "multi": false,
+            "name": "datasource",
+            "options": [],
+            "query": "prometheus",
+            "queryValue": "",
+            "refresh": 1,
+            "regex": "/^(crcs02ue1-prometheus|crcp01ue1-prometheus)$/",
+            "skipUrlSync": false,
+            "type": "datasource"
+          }
+        ]
+      },
+      "time": {
+        "from": "now-15m",
+        "to": "now"
+      },
+      "timepicker": {},
+      "timezone": "",
+      "title": "widget-layout-backend",
+      "uid": "widget-layout-backend-general",
+      "version": 1,
+      "weekStart": ""
+    }
+kind: ConfigMap
+metadata:
+  name: grafana-dashboard-consoledot-insights-widget-layout-backend
+  labels:
+    grafana_dashboard: "true"
+  annotations:
+    grafana-folder: /grafana-dashboard-definitions/Insights

--- a/dashboards/grafana-dashboard-insights-widget-layout-backend-general.configmap.yml
+++ b/dashboards/grafana-dashboard-insights-widget-layout-backend-general.configmap.yml
@@ -49,12 +49,12 @@ data:
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
+                    "color": "red",
                     "value": null
                   },
                   {
-                    "color": "red",
-                    "value": 90
+                    "color": "green",
+                    "value": 0.9
                   }
                 ]
               },
@@ -117,12 +117,12 @@ data:
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
+                    "color": "red",
                     "value": null
                   },
                   {
-                    "color": "red",
-                    "value": 90
+                    "color": "green",
+                    "value": 0.9
                   }
                 ]
               },
@@ -158,7 +158,7 @@ data:
                 "uid": "${datasource}"
               },
               "exemplar": false,
-              "expr": "round(sum(rate(api_3scale_gateway_api_status{exported_service=\"widget-layout-backend\", status=~\"[234]xx\"}[24h])) \n    /\n    sum(rate(api_3scale_gateway_api_status{exported_service=\"widget-layout-backend\"}[24h])), 0.0001)",
+              "expr": "round(sum(rate(api_3scale_gateway_api_status{exported_service=\"widget-layout-backend\", status=~\"2xx\"}[24h])) \n    /\n    sum(rate(api_3scale_gateway_api_status{exported_service=\"widget-layout-backend\"}[24h])), 0.0001)",
               "instant": false,
               "interval": "",
               "legendFormat": "",


### PR DESCRIPTION
## Summary
- Add Grafana dashboard configmap with latency and 2xx response rate gauge panels
- Modeled after chrome-service-backend's dashboard, adapted for widget-layout-backend
- Targets observability namespaces via app-interface (separate MR)

## References
- RHCLOUD-44512
- App-interface MR to follow (uncomments dashboard resource template in deploy.yml)

## Test plan
- [ ] Verify configmap YAML is valid
- [ ] After app-interface MR merges, verify dashboard appears in Grafana

🤖 Generated with [Claude Code](https://claude.com/claude-code)