### PR TITLE
fix: update Grafana dashboard exported_service to widget-layout

### DIFF
--- a/dashboards/grafana-dashboard-insights-widget-layout-backend-general.configmap.yml
+++ b/dashboards/grafana-dashboard-insights-widget-layout-backend-general.configmap.yml
@@ -90,7 +90,7 @@ data:
                 "uid": "${datasource}"
               },
               "exemplar": true,
-              "expr": "sum(rate(api_3scale_gateway_api_time_bucket{le=\"2000.0\", exported_service=\"widget-layout-backend\"}[24h])) / sum(rate(api_3scale_gateway_api_time_bucket{le=\"+Inf\", exported_service=\"widget-layout-backend\"}[24h]))",
+              "expr": "sum(rate(api_3scale_gateway_api_time_bucket{le=\"2000.0\", exported_service=\"widget-layout\"}[24h])) / sum(rate(api_3scale_gateway_api_time_bucket{le=\"+Inf\", exported_service=\"widget-layout\"}[24h]))",
               "interval": "",
               "legendFormat": "",
               "refId": "A"
@@ -158,7 +158,7 @@ data:
                 "uid": "${datasource}"
               },
               "exemplar": false,
-              "expr": "round(sum(rate(api_3scale_gateway_api_status{exported_service=\"widget-layout-backend\", status=~\"2xx\"}[24h])) \n    /\n    sum(rate(api_3scale_gateway_api_status{exported_service=\"widget-layout-backend\"}[24h])), 0.0001)",
+              "expr": "round(sum(rate(api_3scale_gateway_api_status{exported_service=\"widget-layout\", status=~\"2xx\"}[24h])) \n    /\n    sum(rate(api_3scale_gateway_api_status{exported_service=\"widget-layout\"}[24h])), 0.0001)",
               "instant": false,
               "interval": "",
               "legendFormat": "",


### PR DESCRIPTION
## Summary
- Updates `exported_service` label from `widget-layout-backend` to `widget-layout` in both Grafana dashboard Prometheus queries
- Aligns with the actual 3scale gateway service name so the latency and 2xx response gauges render correctly

### Tested in stage, the query should be accurate now:
<img width="579" height="685" alt="image" src="https://github.com/user-attachments/assets/146f60c2-8845-4d58-80f3-7ec49e16c7db" />
