### PR TITLE
docs: add chrome-service data migration guides and script

### DIFF
--- a/docs/chrome-data-migration/MIGRATION_PROD.md
+++ b/docs/chrome-data-migration/MIGRATION_PROD.md
@@ -321,20 +321,25 @@ oc -n chrome-service-prod cp ./widget-migration-script.py debug-container:/tmp/w
 oc -n chrome-service-prod exec -it debug-container -- bash
 ```
 
-### 9.3 Verify DB Connectivity
+### 9.3 Run Preflight Check
 
 ```bash
-echo "Host: $DB_HOST"
-echo "User: $DB_USER"
-echo "DB:   $DB_NAME"
-echo "Port: ${DB_PORT:-5432}"
-
-PGPASSWORD="$DB_PASSWORD" psql \
-    -h "$DB_HOST" -p "${DB_PORT:-5432}" -U "$DB_USER" -d "$DB_NAME" \
-    -c "SELECT COUNT(*) FROM dashboard_templates"
+python3 /tmp/widget-migration-script.py preflight-export
 ```
 
-**IMPORTANT:** Note the exact row count. Production data is critical — document this number before proceeding.
+This checks:
+- DB connectivity and SELECT permissions
+- Active row count in `dashboard_templates`
+- Orphaned rows (no matching `user_identity`) — these will be dropped by the JOIN
+- Users with NULL/empty `account_id` — these would produce NULL `user_id` in target
+- Total exportable rows after JOIN
+
+**IMPORTANT:** All checks must show `[PASS]`. Document the row counts. **STOP if any check shows `[FAIL]`** — investigate before proceeding. Production data is critical.
+
+If the DB secret is not mounted correctly:
+```bash
+env | grep DB_
+```
 
 ### 9.4 Run the Export
 
@@ -418,35 +423,28 @@ oc -n widget-layout-backend-prod cp ./widget-migration-script.py debug-container
 
 ---
 
-## 13. Step 10: Review the Generated SQL
+## 13. Step 10: Run Preflight Check on Target DB
 
-**This review is mandatory for production.** Do not skip.
+**This check is mandatory for production.** Do not skip.
 
 ```bash
 oc -n widget-layout-backend-prod exec -it debug-container -- bash
 ```
 
-Inside the container:
+```bash
+python3 /tmp/widget-migration-script.py preflight-import
+```
+
+This checks:
+- DB connectivity and `dashboard_templates` table exists
+- All expected columns present (`user_id`, `dashboard_name`, `sm`, `md`, `lg`, `xl`, etc.)
+- INSERT permission (inserts a test row and rolls back)
+- Target table is empty (warns about duplicate risk if not)
+- SQL file exists and has INSERT statements
+
+**STOP if any check shows `[FAIL]`.** Investigate before proceeding.
 
 ```bash
-# Count total inserts
-grep -c "^INSERT" /tmp/widget_migration.sql
-
-# Check for NULL user_ids
-grep "VALUES (NULL" /tmp/widget_migration.sql || echo "No NULL user_ids - good"
-
-# Check for empty user_ids
-grep "VALUES (''" /tmp/widget_migration.sql || echo "No empty user_ids - good"
-
-# Sample a few rows for sanity
-head -30 /tmp/widget_migration.sql
-
-# Check the SQL is wrapped in a transaction
-head -5 /tmp/widget_migration.sql
-# Should see BEGIN;
-tail -3 /tmp/widget_migration.sql
-# Should see COMMIT;
-
 exit
 ```
 
@@ -458,19 +456,6 @@ exit
 
 ```bash
 oc -n widget-layout-backend-prod exec -it debug-container -- bash
-```
-
-### 14.2 Verify Target DB Connectivity and Current State
-
-```bash
-echo "Host: $DB_HOST"
-echo "User: $DB_USER"
-echo "DB:   $DB_NAME"
-
-# Record current row count BEFORE migration
-PGPASSWORD="$DB_PASSWORD" psql \
-    -h "$DB_HOST" -p "${DB_PORT:-5432}" -U "$DB_USER" -d "$DB_NAME" \
-    -c "SELECT COUNT(*) FROM dashboard_templates"
 ```
 
 **Document the current row count.** This is your baseline for rollback verification.

--- a/docs/chrome-data-migration/MIGRATION_PROD.md
+++ b/docs/chrome-data-migration/MIGRATION_PROD.md
@@ -91,6 +91,8 @@ Same as staging. The migration script handles these translations automatically:
 | `updated_at` (timestamp) | `updated_at` (timestamp) | Direct copy |
 | `deleted_at` (timestamp) | `deleted_at` (timestamp) | Direct copy |
 
+> **Note on `x`/`y` vs `cx`/`cy` coordinates:** The widget grid items stored in the `sm`/`md`/`lg`/`xl` JSONB columns use `x`/`y` keys. The widget-layout-backend API also uses `x`/`y` at runtime. The `cx`/`cy` naming is only required in YAML configuration files (ConfigMaps, env vars) because YAML parsers treat bare `y` as a boolean. Since this migration copies JSONB directly between PostgreSQL databases — never passing through a YAML parser — no coordinate key renaming is needed.
+
 ---
 
 ## 4. Step 1: Obtain Production Breakglass Access (app-interface MR)

--- a/docs/chrome-data-migration/MIGRATION_PROD.md
+++ b/docs/chrome-data-migration/MIGRATION_PROD.md
@@ -51,7 +51,7 @@ Migrate the `dashboard_templates` table from chrome-service DB to widget-layout-
 
 | Aspect | Staging | Production |
 |--------|---------|------------|
-| **Access type** | `edit-no-secrets` (staging dev role) | Breakglass role (scoped RBAC Role) |
+| **Access type** | `edit` (staging dev role) | Breakglass role (scoped RBAC Role) |
 | **Cluster** | `crcs02ue1` | `crcp01ue1` |
 | **Namespaces** | `chrome-service-stage`, `widget-layout-backend-stage` | `chrome-service-prod`, `widget-layout-backend-prod` |
 | **Read replica requirement** | Not required | Required for InProgress/OnBoarded apps (check with AppSRE) |
@@ -97,7 +97,7 @@ Same as staging. The migration script handles these translations automatically:
 
 ## 4. Step 1: Obtain Production Breakglass Access (app-interface MR)
 
-Production requires a **breakglass role** — `edit-no-secrets` is prohibited on production namespaces per Self-SRE OpenShift Access Standards. Breakglass uses a scoped Kubernetes RBAC Role (not ClusterRole) with explicit permissions.
+Production requires a **breakglass role** — `edit` is prohibited on production namespaces per Self-SRE OpenShift Access Standards. Breakglass uses a scoped Kubernetes RBAC Role (not ClusterRole) with explicit permissions.
 
 ### 4.1 Create the Breakglass RBAC Role Resource
 

--- a/docs/chrome-data-migration/MIGRATION_PROD.md
+++ b/docs/chrome-data-migration/MIGRATION_PROD.md
@@ -2,7 +2,7 @@
 
 Migrate the `dashboard_templates` table from chrome-service DB to widget-layout-backend DB in production.
 
-**IMPORTANT: Complete and verify the [staging migration](./widget-migration-plan-staging.md) before proceeding with production.**
+**IMPORTANT: Complete and verify the [staging migration](./MIGRATION_STAGING.md) before proceeding with production.**
 
 ---
 
@@ -642,5 +642,5 @@ If a full rollback is needed and manual deletion is insufficient, restore the wi
 | Cluster | `crcp01ue1` |
 | Cluster console | `https://console-openshift-console.apps.crcp01ue1.o9m8.p1.openshiftapps.com` |
 | GABI endpoint (prod) | `https://gabi-chrome-service-prod.apps.crcp01ue1.o9m8.p1.openshiftapps.com` |
-| Staging migration plan | `widget-migration-plan-staging.md` |
+| Staging migration plan | `MIGRATION_STAGING.md` |
 | JIRA ticket | RHCLOUD-40883 |

--- a/docs/chrome-data-migration/MIGRATION_PROD.md
+++ b/docs/chrome-data-migration/MIGRATION_PROD.md
@@ -68,6 +68,7 @@ Migrate the `dashboard_templates` table from chrome-service DB to widget-layout-
 - The breakglass MR merged (see Step 1)
 - The migration script `widget-migration-script.py` available locally (same script used in staging)
 - Staging migration results reviewed and confirmed correct
+- Read the "Lessons Learned" section in `MIGRATION_STAGING.md` before proceeding
 
 ---
 
@@ -299,13 +300,15 @@ oc process --local \
 | oc -n chrome-service-prod apply -f -
 ```
 
-Wait for the pod to be ready:
+Wait for the deployment to roll out and get the pod name:
 
 ```bash
-oc -n chrome-service-prod get pod debug-container -w
-```
+oc -n chrome-service-prod rollout status deployment/debug-container --timeout=120s
 
-Wait until `STATUS` shows `Running`. Press `Ctrl+C` to stop watching.
+# Get the actual pod name (it has a hash suffix)
+SOURCE_POD=$(oc -n chrome-service-prod get pods -l app=debug-container -o jsonpath='{.items[0].metadata.name}')
+echo "Source pod: $SOURCE_POD"
+```
 
 ---
 
@@ -314,13 +317,13 @@ Wait until `STATUS` shows `Running`. Press `Ctrl+C` to stop watching.
 ### 9.1 Copy the Migration Script into the Debug-Container
 
 ```bash
-oc -n chrome-service-prod cp ./widget-migration-script.py debug-container:/tmp/widget-migration-script.py
+oc -n chrome-service-prod cp ./widget-migration-script.py "$SOURCE_POD:/tmp/widget-migration-script.py"
 ```
 
 ### 9.2 Exec into the Debug-Container
 
 ```bash
-oc -n chrome-service-prod exec -it debug-container -- bash
+oc -n chrome-service-prod exec -it "$SOURCE_POD" -- bash
 ```
 
 ### 9.3 Run Preflight Check
@@ -340,8 +343,10 @@ This checks:
 
 If the DB secret is not mounted correctly:
 ```bash
-env | grep DB_
+env | grep -E 'PG|DB_'
 ```
+
+> **Note:** The debug-container mounts the secret as `PG*` env vars (`PGHOST`, `PGUSER`, etc.), not `DB_*`. The migration script accepts both formats automatically.
 
 ### 9.4 Run the Export
 
@@ -383,7 +388,7 @@ exit
 ## 10. Step 7: Transfer Files to Local Machine
 
 ```bash
-oc -n chrome-service-prod cp debug-container:/tmp/widget_migration.sql ./widget_migration_prod.sql
+oc -n chrome-service-prod cp "$SOURCE_POD:/tmp/widget_migration.sql" ./widget_migration_prod.sql
 ```
 
 Verify the file was copied:
@@ -406,21 +411,23 @@ oc process --local \
 | oc -n widget-layout-backend-prod apply -f -
 ```
 
-Wait for the pod to be ready:
+Wait for the deployment to roll out and get the pod name:
 
 ```bash
-oc -n widget-layout-backend-prod get pod debug-container -w
-```
+oc -n widget-layout-backend-prod rollout status deployment/debug-container --timeout=120s
 
-Wait until `STATUS` shows `Running`. Press `Ctrl+C` to stop watching.
+# Get the actual pod name
+TARGET_POD=$(oc -n widget-layout-backend-prod get pods -l app=debug-container -o jsonpath='{.items[0].metadata.name}')
+echo "Target pod: $TARGET_POD"
+```
 
 ---
 
 ## 12. Step 9: Transfer Files to Target Debug-Container
 
 ```bash
-oc -n widget-layout-backend-prod cp ./widget_migration_prod.sql debug-container:/tmp/widget_migration.sql
-oc -n widget-layout-backend-prod cp ./widget-migration-script.py debug-container:/tmp/widget-migration-script.py
+oc -n widget-layout-backend-prod cp ./widget_migration_prod.sql "$TARGET_POD:/tmp/widget_migration.sql"
+oc -n widget-layout-backend-prod cp ./widget-migration-script.py "$TARGET_POD:/tmp/widget-migration-script.py"
 ```
 
 ---
@@ -430,7 +437,7 @@ oc -n widget-layout-backend-prod cp ./widget-migration-script.py debug-container
 **This check is mandatory for production.** Do not skip.
 
 ```bash
-oc -n widget-layout-backend-prod exec -it debug-container -- bash
+oc -n widget-layout-backend-prod exec -it "$TARGET_POD" -- bash
 ```
 
 ```bash
@@ -446,6 +453,11 @@ This checks:
 
 **STOP if any check shows `[FAIL]`.** Investigate before proceeding.
 
+> **If "Target table empty" fails:** Inspect existing rows to determine if they are test data or real user data. In production, be cautious about deleting existing rows — verify with the team first:
+> ```bash
+> psql -c "SELECT id, user_id, dashboard_name, created_at FROM dashboard_templates"
+> ```
+
 ```bash
 exit
 ```
@@ -457,7 +469,7 @@ exit
 ### 14.1 Exec into the Target Debug-Container
 
 ```bash
-oc -n widget-layout-backend-prod exec -it debug-container -- bash
+oc -n widget-layout-backend-prod exec -it "$TARGET_POD" -- bash
 ```
 
 **Document the current row count.** This is your baseline for rollback verification.
@@ -495,33 +507,29 @@ exit
 
 ## 15. Step 12: Verify the Migration
 
-### 15.1 Via Debug-Container
+### 15.1 Via Debug-Container (primary method)
 
 ```bash
-oc -n widget-layout-backend-prod exec -it debug-container -- bash
+oc -n widget-layout-backend-prod exec -it "$TARGET_POD" -- bash
 ```
+
+The debug-container sets `PGHOST`, `PGUSER`, `PGPASSWORD`, `PGDATABASE` automatically, so `psql` works without flags:
 
 ```bash
 # Total count — should equal pre-migration count + exported rows
-PGPASSWORD="$DB_PASSWORD" psql \
-    -h "$DB_HOST" -p "${DB_PORT:-5432}" -U "$DB_USER" -d "$DB_NAME" \
-    -c "SELECT COUNT(*) FROM dashboard_templates"
+psql -c "SELECT COUNT(*) FROM dashboard_templates"
 
 # Sample rows — verify user_id and dashboard_name are populated
-PGPASSWORD="$DB_PASSWORD" psql \
-    -h "$DB_HOST" -p "${DB_PORT:-5432}" -U "$DB_USER" -d "$DB_NAME" \
-    -c "SELECT id, user_id, dashboard_name, name, display_name, \"default\" FROM dashboard_templates LIMIT 10"
+psql -c "SELECT id, user_id, dashboard_name, name, display_name, \"default\" FROM dashboard_templates LIMIT 10"
 
 # Check no NULL/empty user_ids (should return 0)
-PGPASSWORD="$DB_PASSWORD" psql \
-    -h "$DB_HOST" -p "${DB_PORT:-5432}" -U "$DB_USER" -d "$DB_NAME" \
-    -c "SELECT COUNT(*) FROM dashboard_templates WHERE user_id IS NULL OR user_id = ''"
+psql -c "SELECT COUNT(*) FROM dashboard_templates WHERE user_id IS NULL OR user_id = ''"
 
-# Check dashboard_name matches display_name for all migrated rows
-PGPASSWORD="$DB_PASSWORD" psql \
-    -h "$DB_HOST" -p "${DB_PORT:-5432}" -U "$DB_USER" -d "$DB_NAME" \
-    -c "SELECT COUNT(*) FROM dashboard_templates WHERE dashboard_name != display_name"
-# Should be 0 for migrated rows
+# Check dashboard_name matches display_name for all migrated rows (should be 0)
+psql -c "SELECT COUNT(*) FROM dashboard_templates WHERE dashboard_name != display_name"
+
+# Verify JSON columns are populated
+psql -c "SELECT COUNT(*) FROM dashboard_templates WHERE sm IS NOT NULL AND sm::text != '[]'"
 ```
 
 ```bash
@@ -554,18 +562,18 @@ curl -H "Authorization: Bearer $TOKEN" "$GABI/query" \
 
 ### 16.1 Delete Debug-Containers (MANDATORY)
 
-Production debug-containers must be removed immediately after use.
+Production debug-containers must be removed immediately after use. Delete the Deployment (not just the pod — the Deployment would recreate it):
 
 ```bash
-oc -n chrome-service-prod delete pod debug-container
-oc -n widget-layout-backend-prod delete pod debug-container
+oc -n chrome-service-prod delete deployment debug-container
+oc -n widget-layout-backend-prod delete deployment debug-container
 ```
 
 Verify they are gone:
 
 ```bash
-oc -n chrome-service-prod get pod debug-container 2>&1 | grep "not found"
-oc -n widget-layout-backend-prod get pod debug-container 2>&1 | grep "not found"
+oc -n chrome-service-prod get deployment debug-container 2>&1 | grep "not found"
+oc -n widget-layout-backend-prod get deployment debug-container 2>&1 | grep "not found"
 ```
 
 ### 16.2 Clean Up Local Files
@@ -600,11 +608,9 @@ If the data was imported successfully but needs to be removed:
 **Option A: Delete all migrated rows (if target DB was empty before migration)**
 
 ```bash
-oc -n widget-layout-backend-prod exec -it debug-container -- bash
+oc -n widget-layout-backend-prod exec -it "$TARGET_POD" -- bash
 
-PGPASSWORD="$DB_PASSWORD" psql \
-    -h "$DB_HOST" -p "${DB_PORT:-5432}" -U "$DB_USER" -d "$DB_NAME" \
-    -c "DELETE FROM dashboard_templates"
+psql -c "DELETE FROM dashboard_templates"
 ```
 
 **Option B: Delete only migrated rows (if target DB had pre-existing data)**
@@ -612,9 +618,7 @@ PGPASSWORD="$DB_PASSWORD" psql \
 Use a timestamp-based filter. The migration preserves original `created_at` timestamps from chrome-service, so you cannot filter by insertion time. Instead, if you recorded the max `id` before migration:
 
 ```bash
-PGPASSWORD="$DB_PASSWORD" psql \
-    -h "$DB_HOST" -p "${DB_PORT:-5432}" -U "$DB_USER" -d "$DB_NAME" \
-    -c "DELETE FROM dashboard_templates WHERE id > <last_pre_migration_id>"
+psql -c "DELETE FROM dashboard_templates WHERE id > <last_pre_migration_id>"
 ```
 
 **Option C: Restore from RDS snapshot**

--- a/docs/chrome-data-migration/MIGRATION_PROD.md
+++ b/docs/chrome-data-migration/MIGRATION_PROD.md
@@ -82,7 +82,7 @@ Same as staging. The migration script handles these translations automatically:
 | `user_identity_id` (uint, FK) | `user_id` (string) | JOIN `user_identities` table to resolve `account_id` |
 | _(does not exist)_ | `dashboard_name` (string) | Copied from `display_name` |
 | `default` (bool) | `default` (bool) | Direct copy |
-| `name` (string, embedded) | `name` (string, embedded) | Direct copy |
+| `name` (string, embedded) | `name` (string, embedded) | Translated via NAME_MAP (e.g., `landingPage` → `landing-landingPage`) |
 | `display_name` (string, embedded) | `display_name` (string, embedded) | Direct copy |
 | `sm` (JSON) | `sm` (JSON) | Direct copy |
 | `md` (JSON) | `md` (JSON) | Direct copy |

--- a/docs/chrome-data-migration/MIGRATION_PROD.md
+++ b/docs/chrome-data-migration/MIGRATION_PROD.md
@@ -1,0 +1,661 @@
+# Widget Dashboard Templates Migration Plan (Production)
+
+Migrate the `dashboard_templates` table from chrome-service DB to widget-layout-backend DB in production.
+
+**IMPORTANT: Complete and verify the [staging migration](./widget-migration-plan-staging.md) before proceeding with production.**
+
+---
+
+## Table of Contents
+
+1. [Overview](#1-overview)
+2. [Prerequisites](#2-prerequisites)
+3. [Schema Translation](#3-schema-translation)
+4. [Step 1: Obtain Production Breakglass Access (app-interface MR)](#4-step-1-obtain-production-breakglass-access-app-interface-mr)
+5. [Step 2: Wait for MR Merge and Reconciliation](#5-step-2-wait-for-mr-merge-and-reconciliation)
+6. [Step 3: Log In to the Cluster](#6-step-3-log-in-to-the-cluster)
+7. [Step 4: Verify Namespace Access](#7-step-4-verify-namespace-access)
+8. [Step 5: Launch Debug-Container in Chrome-Service Namespace (Source)](#8-step-5-launch-debug-container-in-chrome-service-namespace-source)
+9. [Step 6: Export Data from Chrome-Service DB](#9-step-6-export-data-from-chrome-service-db)
+10. [Step 7: Transfer Files to Local Machine](#10-step-7-transfer-files-to-local-machine)
+11. [Step 8: Launch Debug-Container in Widget-Layout Namespace (Target)](#11-step-8-launch-debug-container-in-widget-layout-namespace-target)
+12. [Step 9: Transfer Files to Target Debug-Container](#12-step-9-transfer-files-to-target-debug-container)
+13. [Step 10: Review the Generated SQL](#13-step-10-review-the-generated-sql)
+14. [Step 11: Import Data into Widget-Layout DB](#14-step-11-import-data-into-widget-layout-db)
+15. [Step 12: Verify the Migration](#15-step-12-verify-the-migration)
+16. [Step 13: Clean Up](#16-step-13-clean-up)
+17. [Rollback Procedure](#17-rollback-procedure)
+18. [Reference](#18-reference)
+
+---
+
+## 1. Overview
+
+| Item | Detail |
+|------|--------|
+| **Source DB** | chrome-service PostgreSQL (prod) |
+| **Target DB** | widget-layout-backend PostgreSQL (prod) |
+| **Source table** | `dashboard_templates` (chrome-service) |
+| **Target table** | `dashboard_templates` (widget-layout-backend) |
+| **Cluster** | `crcp01ue1` — both namespaces are on the same cluster |
+| **Source namespace** | `chrome-service-prod` |
+| **Target namespace** | `widget-layout-backend-prod` |
+| **Source DB secret** | `chrome-service-db` |
+| **Target DB secret** | `widget-layout-backend-db` |
+| **Method** | Python script using `psycopg2` inside debug-containers |
+| **Migration script** | `widget-migration-script.py` |
+| **Access method** | Breakglass role (required for production) |
+| **Authorized users** | tefaz, khala, bflorkie, mmarosi |
+
+### Key Differences from Staging
+
+| Aspect | Staging | Production |
+|--------|---------|------------|
+| **Access type** | `edit-no-secrets` (staging dev role) | Breakglass role (scoped RBAC Role) |
+| **Cluster** | `crcs02ue1` | `crcp01ue1` |
+| **Namespaces** | `chrome-service-stage`, `widget-layout-backend-stage` | `chrome-service-prod`, `widget-layout-backend-prod` |
+| **Read replica requirement** | Not required | Required for InProgress/OnBoarded apps (check with AppSRE) |
+| **Approval** | Self-serviceable via `platform-experience` role | Requires AppSRE review for breakglass |
+| **Risk** | Low — staging data only | High — real user data |
+
+---
+
+## 2. Prerequisites
+
+- Staging migration completed and verified successfully
+- `oc` CLI installed locally
+- Access to the `crcp01ue1` OpenShift cluster console
+- The breakglass MR merged (see Step 1)
+- The migration script `widget-migration-script.py` available locally (same script used in staging)
+- Staging migration results reviewed and confirmed correct
+
+---
+
+## 3. Schema Translation
+
+Same as staging. The migration script handles these translations automatically:
+
+| Chrome-Service Column | Widget-Layout Column | Translation |
+|-----------------------|----------------------|-------------|
+| `id` (uint, PK) | `id` (uint, PK) | Auto-generated in target (not copied) |
+| `user_identity_id` (uint, FK) | `user_id` (string) | JOIN `user_identities` table to resolve `account_id` |
+| _(does not exist)_ | `dashboard_name` (string) | Copied from `display_name` |
+| `default` (bool) | `default` (bool) | Direct copy |
+| `name` (string, embedded) | `name` (string, embedded) | Direct copy |
+| `display_name` (string, embedded) | `display_name` (string, embedded) | Direct copy |
+| `sm` (JSON) | `sm` (JSON) | Direct copy |
+| `md` (JSON) | `md` (JSON) | Direct copy |
+| `lg` (JSON) | `lg` (JSON) | Direct copy |
+| `xl` (JSON) | `xl` (JSON) | Direct copy |
+| `created_at` (timestamp) | `created_at` (timestamp) | Direct copy |
+| `updated_at` (timestamp) | `updated_at` (timestamp) | Direct copy |
+| `deleted_at` (timestamp) | `deleted_at` (timestamp) | Direct copy |
+
+---
+
+## 4. Step 1: Obtain Production Breakglass Access (app-interface MR)
+
+Production requires a **breakglass role** — `edit-no-secrets` is prohibited on production namespaces per Self-SRE OpenShift Access Standards. Breakglass uses a scoped Kubernetes RBAC Role (not ClusterRole) with explicit permissions.
+
+### 4.1 Create the Breakglass RBAC Role Resource
+
+File: `resources/services/insights/chrome-service/rbac/widget-migration-breakglass.role.yaml`
+
+```yaml
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: widget-migration-breakglass
+rules:
+# Create and manage debug pods
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["create", "list", "get", "delete"]
+# Exec into pods for running migration
+- apiGroups: [""]
+  resources: ["pods/exec"]
+  verbs: ["create", "get"]
+# Read DB secret (named explicitly)
+- apiGroups: [""]
+  resources: ["secrets"]
+  resourceNames: ["chrome-service-db"]
+  verbs: ["get"]
+```
+
+Create a similar file for widget-layout-backend:
+
+File: `resources/services/insights/widget-layout-backend/rbac/widget-migration-breakglass.role.yaml`
+
+```yaml
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: widget-migration-breakglass
+rules:
+# Create and manage debug pods
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["create", "list", "get", "delete"]
+# Exec into pods for running migration
+- apiGroups: [""]
+  resources: ["pods/exec"]
+  verbs: ["create", "get"]
+# Read DB secret (named explicitly)
+- apiGroups: [""]
+  resources: ["secrets"]
+  resourceNames: ["widget-layout-backend-db"]
+  verbs: ["get"]
+```
+
+### 4.2 Create the Breakglass Role File
+
+File: `data/teams/insights/roles/platform-experience-breakglass.yml`
+
+```yaml
+---
+
+$schema: /access/role-1.yml
+
+labels: {}
+name: platform-experience-breakglass
+
+description: |
+  Breakglass role for production dashboard_templates data migration
+  from chrome-service to widget-layout-backend. Scoped to debug pod
+  creation, exec, and named DB secret access only.
+
+permissions: []
+
+expirationDate: '2026-06-08'
+
+access:
+- namespace:
+    $ref: /services/insights/chrome-service/namespaces/chrome-service-prod.yml
+  role: widget-migration-breakglass
+- namespace:
+    $ref: /services/insights/widget-layout-backend/namespaces/crcp01ue1-widget-layout-backend-prod.yml
+  role: widget-migration-breakglass
+
+self_service:
+- change_type:
+    $ref: /app-interface/changetype/breakglass-role-manager.yml
+  datafiles:
+  - $ref: /teams/insights/roles/platform-experience-breakglass.yml
+```
+
+### 4.3 Add Role to User Files
+
+Add the following line to the `roles:` section of each user file in `data/teams/insights/users/`:
+
+```yaml
+- $ref: /teams/insights/roles/platform-experience-breakglass.yml
+```
+
+Users to update:
+- `tefaz.yml`
+- `khala.yml`
+- `bflorkie.yml`
+- `mmarosi.yml`
+
+### 4.4 Add Resource Paths to Self-Service
+
+Ensure the breakglass RBAC resource files are listed in the team's `resource-owner` self-service section so changes to these resources can be self-approved. Check the `platform-experience` or `platform-experience-services` role file and add:
+
+```yaml
+- change_type:
+    $ref: /app-interface/changetype/resource-owner.yml
+  resources:
+  - /services/insights/chrome-service/rbac/widget-migration-breakglass.role.yaml
+  - /services/insights/widget-layout-backend/rbac/widget-migration-breakglass.role.yaml
+```
+
+### 4.5 Commit, Push, and Create MR
+
+```bash
+cd /path/to/app-interface
+git fetch upstream master
+git checkout -b widget-migration-prod-breakglass upstream/master
+# ... make the changes above ...
+git add <all new and modified files>
+git commit -m "Add breakglass role for prod widget migration"
+git push origin widget-migration-prod-breakglass
+```
+
+Create MR targeting `service/app-interface` master. This MR will require AppSRE review since it involves production access.
+
+---
+
+## 5. Step 2: Wait for MR Merge and Reconciliation
+
+1. Get MR reviewed and approved (requires AppSRE approval for production breakglass)
+2. Once merged, wait for `qontract-reconcile` to apply the RBAC changes (5-15 minutes)
+3. Verify:
+   ```bash
+   oc auth can-i create pods -n chrome-service-prod
+   ```
+   Should return `yes` once reconciliation is complete.
+
+---
+
+## 6. Step 3: Log In to the Cluster
+
+1. Navigate to the `crcp01ue1` cluster console:
+   ```
+   https://console-openshift-console.apps.crcp01ue1.o9m8.p1.openshiftapps.com
+   ```
+
+2. Click your username (top right) -> **Copy login command** -> **Display Token**
+
+3. Copy the `oc login` command and run it in your terminal:
+   ```bash
+   oc login --token=sha256~<your-token> --server=https://api.crcp01ue1.o9m8.p1.openshiftapps.com:6443
+   ```
+
+4. Verify login:
+   ```bash
+   oc whoami
+   ```
+
+---
+
+## 7. Step 4: Verify Namespace Access
+
+```bash
+# Check chrome-service-prod
+oc auth can-i create pods -n chrome-service-prod
+# Expected: yes
+
+oc auth can-i create pods/exec -n chrome-service-prod
+# Expected: yes
+
+oc auth can-i get secrets --field-selector=metadata.name=chrome-service-db -n chrome-service-prod
+# Expected: yes
+
+# Check widget-layout-backend-prod
+oc auth can-i create pods -n widget-layout-backend-prod
+# Expected: yes
+
+oc auth can-i create pods/exec -n widget-layout-backend-prod
+# Expected: yes
+
+oc auth can-i get secrets --field-selector=metadata.name=widget-layout-backend-db -n widget-layout-backend-prod
+# Expected: yes
+```
+
+If any return `no`, the RBAC hasn't reconciled yet. Wait a few more minutes and retry.
+
+---
+
+## 8. Step 5: Launch Debug-Container in Chrome-Service Namespace (Source)
+
+```bash
+oc process --local \
+    -f https://raw.githubusercontent.com/app-sre/container-images/master/debug-container/openshift.yml \
+    -p POSTGRES_DB_SECRET_NAME="chrome-service-db" \
+| oc -n chrome-service-prod apply -f -
+```
+
+Wait for the pod to be ready:
+
+```bash
+oc -n chrome-service-prod get pod debug-container -w
+```
+
+Wait until `STATUS` shows `Running`. Press `Ctrl+C` to stop watching.
+
+---
+
+## 9. Step 6: Export Data from Chrome-Service DB
+
+### 9.1 Copy the Migration Script into the Debug-Container
+
+```bash
+oc -n chrome-service-prod cp ./widget-migration-script.py debug-container:/tmp/widget-migration-script.py
+```
+
+### 9.2 Exec into the Debug-Container
+
+```bash
+oc -n chrome-service-prod exec -it debug-container -- bash
+```
+
+### 9.3 Verify DB Connectivity
+
+```bash
+echo "Host: $DB_HOST"
+echo "User: $DB_USER"
+echo "DB:   $DB_NAME"
+echo "Port: ${DB_PORT:-5432}"
+
+PGPASSWORD="$DB_PASSWORD" psql \
+    -h "$DB_HOST" -p "${DB_PORT:-5432}" -U "$DB_USER" -d "$DB_NAME" \
+    -c "SELECT COUNT(*) FROM dashboard_templates"
+```
+
+**IMPORTANT:** Note the exact row count. Production data is critical — document this number before proceeding.
+
+### 9.4 Run the Export
+
+```bash
+python3 /tmp/widget-migration-script.py export
+```
+
+Expected output:
+```
+Found N active dashboard_templates rows
+Fetched N rows (with user_id resolved)
+Generated N INSERT statements in /tmp/widget_migration.sql
+```
+
+### 9.5 Verify Export Data
+
+```bash
+# Check row count matches
+grep -c "^INSERT" /tmp/widget_migration.sql
+
+# Inspect first few statements
+head -30 /tmp/widget_migration.sql
+
+# Check for NULL user_ids (failed JOINs)
+grep "VALUES (''" /tmp/widget_migration.sql | wc -l
+# Should be 0
+```
+
+**STOP if any NULL user_ids are found.** This means some `user_identity_id` values don't have matching `user_identities` rows. Investigate before proceeding.
+
+### 9.6 Exit the Container
+
+```bash
+exit
+```
+
+---
+
+## 10. Step 7: Transfer Files to Local Machine
+
+```bash
+oc -n chrome-service-prod cp debug-container:/tmp/widget_migration.sql ./widget_migration_prod.sql
+```
+
+Verify the file was copied:
+
+```bash
+head -20 ./widget_migration_prod.sql
+grep -c "^INSERT" ./widget_migration_prod.sql
+```
+
+**Recommended:** Compare prod row count with staging to ensure they are in the expected ratio. If prod has significantly fewer or more rows than expected, investigate.
+
+---
+
+## 11. Step 8: Launch Debug-Container in Widget-Layout Namespace (Target)
+
+```bash
+oc process --local \
+    -f https://raw.githubusercontent.com/app-sre/container-images/master/debug-container/openshift.yml \
+    -p POSTGRES_DB_SECRET_NAME="widget-layout-backend-db" \
+| oc -n widget-layout-backend-prod apply -f -
+```
+
+Wait for the pod to be ready:
+
+```bash
+oc -n widget-layout-backend-prod get pod debug-container -w
+```
+
+Wait until `STATUS` shows `Running`. Press `Ctrl+C` to stop watching.
+
+---
+
+## 12. Step 9: Transfer Files to Target Debug-Container
+
+```bash
+oc -n widget-layout-backend-prod cp ./widget_migration_prod.sql debug-container:/tmp/widget_migration.sql
+oc -n widget-layout-backend-prod cp ./widget-migration-script.py debug-container:/tmp/widget-migration-script.py
+```
+
+---
+
+## 13. Step 10: Review the Generated SQL
+
+**This review is mandatory for production.** Do not skip.
+
+```bash
+oc -n widget-layout-backend-prod exec -it debug-container -- bash
+```
+
+Inside the container:
+
+```bash
+# Count total inserts
+grep -c "^INSERT" /tmp/widget_migration.sql
+
+# Check for NULL user_ids
+grep "VALUES (NULL" /tmp/widget_migration.sql || echo "No NULL user_ids - good"
+
+# Check for empty user_ids
+grep "VALUES (''" /tmp/widget_migration.sql || echo "No empty user_ids - good"
+
+# Sample a few rows for sanity
+head -30 /tmp/widget_migration.sql
+
+# Check the SQL is wrapped in a transaction
+head -5 /tmp/widget_migration.sql
+# Should see BEGIN;
+tail -3 /tmp/widget_migration.sql
+# Should see COMMIT;
+
+exit
+```
+
+---
+
+## 14. Step 11: Import Data into Widget-Layout DB
+
+### 14.1 Exec into the Target Debug-Container
+
+```bash
+oc -n widget-layout-backend-prod exec -it debug-container -- bash
+```
+
+### 14.2 Verify Target DB Connectivity and Current State
+
+```bash
+echo "Host: $DB_HOST"
+echo "User: $DB_USER"
+echo "DB:   $DB_NAME"
+
+# Record current row count BEFORE migration
+PGPASSWORD="$DB_PASSWORD" psql \
+    -h "$DB_HOST" -p "${DB_PORT:-5432}" -U "$DB_USER" -d "$DB_NAME" \
+    -c "SELECT COUNT(*) FROM dashboard_templates"
+```
+
+**Document the current row count.** This is your baseline for rollback verification.
+
+### 14.3 Run the Import
+
+```bash
+python3 /tmp/widget-migration-script.py import
+```
+
+The script will:
+1. Show the number of INSERT statements found
+2. Ask for confirmation: `Proceed with import? (y/N):`
+3. **Double-check the count matches your export count before typing `y`**
+4. Type `y` and press Enter
+5. Execute all INSERTs inside a transaction (auto-rollback on any error)
+6. Print the final row count in the target table
+
+Expected output:
+```
+Found N INSERT statements in /tmp/widget_migration.sql
+Proceed with import? (y/N): y
+Running import...
+Target DB now has N dashboard_templates rows
+Done.
+```
+
+### 14.4 Exit the Container
+
+```bash
+exit
+```
+
+---
+
+## 15. Step 12: Verify the Migration
+
+### 15.1 Via Debug-Container
+
+```bash
+oc -n widget-layout-backend-prod exec -it debug-container -- bash
+```
+
+```bash
+# Total count — should equal pre-migration count + exported rows
+PGPASSWORD="$DB_PASSWORD" psql \
+    -h "$DB_HOST" -p "${DB_PORT:-5432}" -U "$DB_USER" -d "$DB_NAME" \
+    -c "SELECT COUNT(*) FROM dashboard_templates"
+
+# Sample rows — verify user_id and dashboard_name are populated
+PGPASSWORD="$DB_PASSWORD" psql \
+    -h "$DB_HOST" -p "${DB_PORT:-5432}" -U "$DB_USER" -d "$DB_NAME" \
+    -c "SELECT id, user_id, dashboard_name, name, display_name, \"default\" FROM dashboard_templates LIMIT 10"
+
+# Check no NULL/empty user_ids (should return 0)
+PGPASSWORD="$DB_PASSWORD" psql \
+    -h "$DB_HOST" -p "${DB_PORT:-5432}" -U "$DB_USER" -d "$DB_NAME" \
+    -c "SELECT COUNT(*) FROM dashboard_templates WHERE user_id IS NULL OR user_id = ''"
+
+# Check dashboard_name matches display_name for all migrated rows
+PGPASSWORD="$DB_PASSWORD" psql \
+    -h "$DB_HOST" -p "${DB_PORT:-5432}" -U "$DB_USER" -d "$DB_NAME" \
+    -c "SELECT COUNT(*) FROM dashboard_templates WHERE dashboard_name != display_name"
+# Should be 0 for migrated rows
+```
+
+```bash
+exit
+```
+
+### 15.2 Via the Widget-Layout API
+
+Test the API to confirm the application can read migrated data:
+
+```bash
+curl -H "x-rh-identity: <base64-encoded-identity>" \
+    https://<prod-api>/api/widget-layout/v1/
+```
+
+### 15.3 Via GABI (if configured)
+
+```bash
+TOKEN="sha256~<your-token>"
+GABI="https://gabi-chrome-service-prod.apps.crcp01ue1.o9m8.p1.openshiftapps.com"
+
+# Verify source data is unchanged
+curl -H "Authorization: Bearer $TOKEN" "$GABI/query" \
+    -d '{"query": "SELECT COUNT(*) FROM dashboard_templates"}' -s | jq
+```
+
+---
+
+## 16. Step 13: Clean Up
+
+### 16.1 Delete Debug-Containers (MANDATORY)
+
+Production debug-containers must be removed immediately after use.
+
+```bash
+oc -n chrome-service-prod delete pod debug-container
+oc -n widget-layout-backend-prod delete pod debug-container
+```
+
+Verify they are gone:
+
+```bash
+oc -n chrome-service-prod get pod debug-container 2>&1 | grep "not found"
+oc -n widget-layout-backend-prod get pod debug-container 2>&1 | grep "not found"
+```
+
+### 16.2 Clean Up Local Files
+
+```bash
+rm ./widget_migration_prod.sql
+```
+
+### 16.3 Remove Breakglass Role
+
+Submit an MR to remove the breakglass access:
+
+1. Remove `- $ref: /teams/insights/roles/platform-experience-breakglass.yml` from all 4 user files
+2. Delete `data/teams/insights/roles/platform-experience-breakglass.yml`
+3. Delete `resources/services/insights/chrome-service/rbac/widget-migration-breakglass.role.yaml`
+4. Delete `resources/services/insights/widget-layout-backend/rbac/widget-migration-breakglass.role.yaml`
+
+Or let it expire on `2026-06-08`. However, removing promptly is preferred for production breakglass.
+
+---
+
+## 17. Rollback Procedure
+
+### Automatic Rollback
+
+The migration script wraps all INSERTs in a `BEGIN`/`COMMIT` transaction. If any INSERT fails, the entire transaction is rolled back automatically. No partial data will be written.
+
+### Manual Rollback (after successful import)
+
+If the data was imported successfully but needs to be removed:
+
+**Option A: Delete all migrated rows (if target DB was empty before migration)**
+
+```bash
+oc -n widget-layout-backend-prod exec -it debug-container -- bash
+
+PGPASSWORD="$DB_PASSWORD" psql \
+    -h "$DB_HOST" -p "${DB_PORT:-5432}" -U "$DB_USER" -d "$DB_NAME" \
+    -c "DELETE FROM dashboard_templates"
+```
+
+**Option B: Delete only migrated rows (if target DB had pre-existing data)**
+
+Use a timestamp-based filter. The migration preserves original `created_at` timestamps from chrome-service, so you cannot filter by insertion time. Instead, if you recorded the max `id` before migration:
+
+```bash
+PGPASSWORD="$DB_PASSWORD" psql \
+    -h "$DB_HOST" -p "${DB_PORT:-5432}" -U "$DB_USER" -d "$DB_NAME" \
+    -c "DELETE FROM dashboard_templates WHERE id > <last_pre_migration_id>"
+```
+
+**Option C: Restore from RDS snapshot**
+
+If a full rollback is needed and manual deletion is insufficient, restore the widget-layout-backend-prod RDS instance from a pre-migration snapshot via AWS console or app-interface.
+
+**IMPORTANT:** After any rollback, verify the application is functioning correctly.
+
+---
+
+## 18. Reference
+
+| Resource | Location |
+|----------|----------|
+| Migration script | `widget-migration-script.py` (local) |
+| Breakglass MR branch | `widget-migration-prod-breakglass` (to be created) |
+| Breakglass role file | `data/teams/insights/roles/platform-experience-breakglass.yml` |
+| Chrome-service breakglass RBAC | `resources/services/insights/chrome-service/rbac/widget-migration-breakglass.role.yaml` |
+| Widget-layout breakglass RBAC | `resources/services/insights/widget-layout-backend/rbac/widget-migration-breakglass.role.yaml` |
+| Debug-container docs | `docs/app-sre/sops/general/debug-container.md` |
+| Self-SRE access docs | `docs/platform-users/access/self-sre-openshift-access.md` |
+| DB connection docs | `docs/platform-users/external-resources/aws/rds/connect-to-postgres-mysql-database.md` |
+| Chrome-service prod namespace | `data/services/insights/chrome-service/namespaces/chrome-service-prod.yml` |
+| Widget-layout prod namespace | `data/services/insights/widget-layout-backend/namespaces/crcp01ue1-widget-layout-backend-prod.yml` |
+| Chrome-service DB secret name | `chrome-service-db` |
+| Widget-layout DB secret name | `widget-layout-backend-db` |
+| Cluster | `crcp01ue1` |
+| Cluster console | `https://console-openshift-console.apps.crcp01ue1.o9m8.p1.openshiftapps.com` |
+| GABI endpoint (prod) | `https://gabi-chrome-service-prod.apps.crcp01ue1.o9m8.p1.openshiftapps.com` |
+| Staging migration plan | `widget-migration-plan-staging.md` |
+| JIRA ticket | RHCLOUD-40883 |

--- a/docs/chrome-data-migration/MIGRATION_PROD.md
+++ b/docs/chrome-data-migration/MIGRATION_PROD.md
@@ -348,7 +348,17 @@ env | grep -E 'PG|DB_'
 
 > **Note:** The debug-container mounts the secret as `PG*` env vars (`PGHOST`, `PGUSER`, etc.), not `DB_*`. The migration script accepts both formats automatically.
 
-### 9.4 Run the Export
+### 9.4 Verify NAME_MAP Completeness
+
+The migration script translates template names via `NAME_MAP`. Before exporting, verify that all distinct names in production are covered:
+
+```sql
+SELECT DISTINCT name FROM dashboard_templates WHERE deleted_at IS NULL;
+```
+
+Compare the output against `NAME_MAP` in `widget-migration-script.py`. If any names are missing, add them to the map before proceeding — the export will abort if it encounters an unmapped name.
+
+### 9.5 Run the Export
 
 ```bash
 python3 /tmp/widget-migration-script.py export
@@ -361,7 +371,7 @@ Fetched N rows (with user_id resolved)
 Generated N INSERT statements in /tmp/widget_migration.sql
 ```
 
-### 9.5 Verify Export Data
+### 9.6 Verify Export Data
 
 ```bash
 # Check row count matches
@@ -377,7 +387,7 @@ grep "VALUES (''" /tmp/widget_migration.sql | wc -l
 
 **STOP if any NULL user_ids are found.** This means some `user_identity_id` values don't have matching `user_identities` rows. Investigate before proceeding.
 
-### 9.6 Exit the Container
+### 9.7 Exit the Container
 
 ```bash
 exit
@@ -471,6 +481,8 @@ exit
 ```bash
 oc -n widget-layout-backend-prod exec -it "$TARGET_POD" -- bash
 ```
+
+### 14.2 Document Baseline Row Count
 
 **Document the current row count.** This is your baseline for rollback verification.
 

--- a/docs/chrome-data-migration/MIGRATION_PROD.md
+++ b/docs/chrome-data-migration/MIGRATION_PROD.md
@@ -20,7 +20,7 @@ Migrate the `dashboard_templates` table from chrome-service DB to widget-layout-
 10. [Step 7: Transfer Files to Local Machine](#10-step-7-transfer-files-to-local-machine)
 11. [Step 8: Launch Debug-Container in Widget-Layout Namespace (Target)](#11-step-8-launch-debug-container-in-widget-layout-namespace-target)
 12. [Step 9: Transfer Files to Target Debug-Container](#12-step-9-transfer-files-to-target-debug-container)
-13. [Step 10: Review the Generated SQL](#13-step-10-review-the-generated-sql)
+13. [Step 10: Run Preflight Check on Target DB](#13-step-10-run-preflight-check-on-target-db)
 14. [Step 11: Import Data into Widget-Layout DB](#14-step-11-import-data-into-widget-layout-db)
 15. [Step 12: Verify the Migration](#15-step-12-verify-the-migration)
 16. [Step 13: Clean Up](#16-step-13-clean-up)

--- a/docs/chrome-data-migration/MIGRATION_STAGING.md
+++ b/docs/chrome-data-migration/MIGRATION_STAGING.md
@@ -18,7 +18,7 @@ Migrate the `dashboard_templates` table from chrome-service DB to widget-layout-
 10. [Step 7: Transfer Files to Local Machine](#10-step-7-transfer-files-to-local-machine)
 11. [Step 8: Launch Debug-Container in Widget-Layout Namespace (Target)](#11-step-8-launch-debug-container-in-widget-layout-namespace-target)
 12. [Step 9: Transfer Files to Target Debug-Container](#12-step-9-transfer-files-to-target-debug-container)
-13. [Step 10: Review the Generated SQL](#13-step-10-review-the-generated-sql)
+13. [Step 10: Run Preflight Check on Target DB](#13-step-10-run-preflight-check-on-target-db)
 14. [Step 11: Import Data into Widget-Layout DB](#14-step-11-import-data-into-widget-layout-db)
 15. [Step 12: Verify the Migration](#15-step-12-verify-the-migration)
 16. [Step 13: Clean Up](#16-step-13-clean-up)

--- a/docs/chrome-data-migration/MIGRATION_STAGING.md
+++ b/docs/chrome-data-migration/MIGRATION_STAGING.md
@@ -81,7 +81,7 @@ The two databases use different schemas for the same conceptual table. The migra
 | `user_identity_id` (uint, FK) | `user_id` (string) | JOIN `user_identities` table to resolve `account_id` |
 | _(does not exist)_ | `dashboard_name` (string) | Copied from `display_name` |
 | `default` (bool) | `default` (bool) | Direct copy |
-| `name` (string, embedded) | `name` (string, embedded) | Direct copy |
+| `name` (string, embedded) | `name` (string, embedded) | Translated via NAME_MAP (e.g., `landingPage` → `landing-landingPage`) |
 | `display_name` (string, embedded) | `display_name` (string, embedded) | Direct copy |
 | `sm` (JSON) | `sm` (JSON) | Direct copy |
 | `md` (JSON) | `md` (JSON) | Direct copy |

--- a/docs/chrome-data-migration/MIGRATION_STAGING.md
+++ b/docs/chrome-data-migration/MIGRATION_STAGING.md
@@ -55,6 +55,22 @@ Migrate the `dashboard_templates` table from chrome-service DB to widget-layout-
 
 ---
 
+## Lessons Learned (from 2026-05-11 staging run)
+
+These issues were encountered during the first staging migration. The instructions below have been updated to account for them, but they are documented here for awareness:
+
+1. **Debug-container env vars use `PG*` prefix, not `DB_*`**: The debug-container template mounts the DB secret as `PGHOST`, `PGUSER`, `PGPASSWORD`, `PGDATABASE`, `PGPORT` — not `DB_HOST`, `DB_USER`, etc. The migration script has been updated to accept both formats automatically.
+
+2. **Debug-container creates a Deployment, not a bare Pod**: The `oc process` command creates a Deployment, which produces pods with a hash suffix (e.g., `debug-container-cff5b7cb9-gfv9r`). You must look up the actual pod name via label selector before using `oc cp` or `oc exec`. Cleanup must delete the Deployment, not the pod.
+
+3. **Target table may have existing rows**: If the widget-layout-backend API is already deployed in stage, users or tests may have created rows. The preflight-import check will `[FAIL]` on "Target table empty". Clear these rows before importing if they are test data.
+
+4. **No external route for stage API**: The `widget-layout-backend-stage` namespace has no Route, so API-level verification (Step 12.3) is not available in staging. Debug-container psql verification is sufficient.
+
+5. **`psql` reads PG* vars natively**: Inside the debug-container, you can run `psql` without `-h`/`-U`/`-d` flags — it picks up `PGHOST`, `PGUSER`, `PGPASSWORD`, `PGDATABASE` automatically.
+
+---
+
 ## 3. Schema Translation
 
 The two databases use different schemas for the same conceptual table. The migration script handles these translations automatically:
@@ -226,13 +242,15 @@ oc process --local \
 | oc -n chrome-service-stage apply -f -
 ```
 
-Wait for the pod to be ready:
+Wait for the deployment to roll out and get the pod name:
 
 ```bash
-oc -n chrome-service-stage get pod debug-container -w
-```
+oc -n chrome-service-stage rollout status deployment/debug-container --timeout=120s
 
-Wait until `STATUS` shows `Running`. Press `Ctrl+C` to stop watching.
+# Get the actual pod name (it has a hash suffix)
+SOURCE_POD=$(oc -n chrome-service-stage get pods -l app=debug-container -o jsonpath='{.items[0].metadata.name}')
+echo "Source pod: $SOURCE_POD"
+```
 
 ---
 
@@ -241,13 +259,13 @@ Wait until `STATUS` shows `Running`. Press `Ctrl+C` to stop watching.
 ### 9.1 Copy the Migration Script into the Debug-Container
 
 ```bash
-oc -n chrome-service-stage cp ./widget-migration-script.py debug-container:/tmp/widget-migration-script.py
+oc -n chrome-service-stage cp ./widget-migration-script.py "$SOURCE_POD:/tmp/widget-migration-script.py"
 ```
 
 ### 9.2 Exec into the Debug-Container
 
 ```bash
-oc -n chrome-service-stage exec -it debug-container -- bash
+oc -n chrome-service-stage exec -it "$SOURCE_POD" -- bash
 ```
 
 ### 9.3 Run Preflight Check
@@ -267,8 +285,10 @@ All checks must show `[PASS]`. If any show `[FAIL]`, investigate before proceedi
 
 If the DB secret is not mounted correctly:
 ```bash
-env | grep DB_
+env | grep -E 'PG|DB_'
 ```
+
+> **Note:** The debug-container mounts the secret as `PG*` env vars (`PGHOST`, `PGUSER`, etc.), not `DB_*`. The migration script accepts both formats automatically.
 
 ### 9.4 Run the Export
 
@@ -306,10 +326,10 @@ exit
 
 ## 10. Step 7: Transfer Files to Local Machine
 
-Copy the generated SQL and the migration script from the source debug-container to your local machine:
+Copy the generated SQL from the source debug-container to your local machine:
 
 ```bash
-oc -n chrome-service-stage cp debug-container:/tmp/widget_migration.sql ./widget_migration.sql
+oc -n chrome-service-stage cp "$SOURCE_POD:/tmp/widget_migration.sql" ./widget_migration.sql
 ```
 
 Verify the file was copied:
@@ -330,21 +350,23 @@ oc process --local \
 | oc -n widget-layout-backend-stage apply -f -
 ```
 
-Wait for the pod to be ready:
+Wait for the deployment to roll out and get the pod name:
 
 ```bash
-oc -n widget-layout-backend-stage get pod debug-container -w
-```
+oc -n widget-layout-backend-stage rollout status deployment/debug-container --timeout=120s
 
-Wait until `STATUS` shows `Running`. Press `Ctrl+C` to stop watching.
+# Get the actual pod name
+TARGET_POD=$(oc -n widget-layout-backend-stage get pods -l app=debug-container -o jsonpath='{.items[0].metadata.name}')
+echo "Target pod: $TARGET_POD"
+```
 
 ---
 
 ## 12. Step 9: Transfer Files to Target Debug-Container
 
 ```bash
-oc -n widget-layout-backend-stage cp ./widget_migration.sql debug-container:/tmp/widget_migration.sql
-oc -n widget-layout-backend-stage cp ./widget-migration-script.py debug-container:/tmp/widget-migration-script.py
+oc -n widget-layout-backend-stage cp ./widget_migration.sql "$TARGET_POD:/tmp/widget_migration.sql"
+oc -n widget-layout-backend-stage cp ./widget-migration-script.py "$TARGET_POD:/tmp/widget-migration-script.py"
 ```
 
 ---
@@ -352,7 +374,7 @@ oc -n widget-layout-backend-stage cp ./widget-migration-script.py debug-containe
 ## 13. Step 10: Run Preflight Check on Target DB
 
 ```bash
-oc -n widget-layout-backend-stage exec -it debug-container -- bash
+oc -n widget-layout-backend-stage exec -it "$TARGET_POD" -- bash
 ```
 
 ```bash
@@ -368,6 +390,13 @@ This checks:
 
 All checks must show `[PASS]`. If any show `[FAIL]`, investigate before proceeding.
 
+> **If "Target table empty" fails:** The stage API may have created test rows. Verify they are test data, then clear them:
+> ```bash
+> psql -c "SELECT id, user_id, dashboard_name, created_at FROM dashboard_templates"
+> psql -c "DELETE FROM dashboard_templates"
+> ```
+> Re-run preflight-import after clearing.
+
 ```bash
 exit
 ```
@@ -379,7 +408,7 @@ exit
 ### 14.1 Exec into the Target Debug-Container
 
 ```bash
-oc -n widget-layout-backend-stage exec -it debug-container -- bash
+oc -n widget-layout-backend-stage exec -it "$TARGET_POD" -- bash
 ```
 
 ### 14.2 Run the Import
@@ -414,36 +443,37 @@ exit
 
 ## 15. Step 12: Verify the Migration
 
-### 15.1 Via Debug-Container
+### 15.1 Via Debug-Container (primary method)
 
 ```bash
-oc -n widget-layout-backend-stage exec -it debug-container -- bash
+oc -n widget-layout-backend-stage exec -it "$TARGET_POD" -- bash
 ```
 
+The debug-container sets `PGHOST`, `PGUSER`, `PGPASSWORD`, `PGDATABASE` automatically, so `psql` works without flags:
+
 ```bash
-# Total count
-PGPASSWORD="$DB_PASSWORD" psql \
-    -h "$DB_HOST" -p "${DB_PORT:-5432}" -U "$DB_USER" -d "$DB_NAME" \
-    -c "SELECT COUNT(*) FROM dashboard_templates"
+# Total count — must match source export count
+psql -c "SELECT COUNT(*) FROM dashboard_templates"
 
 # Sample a few rows
-PGPASSWORD="$DB_PASSWORD" psql \
-    -h "$DB_HOST" -p "${DB_PORT:-5432}" -U "$DB_USER" -d "$DB_NAME" \
-    -c "SELECT id, user_id, dashboard_name, name, display_name, \"default\" FROM dashboard_templates LIMIT 5"
+psql -c "SELECT id, user_id, dashboard_name, name, display_name, \"default\" FROM dashboard_templates LIMIT 5"
 
 # Check user_id is populated (should return 0)
-PGPASSWORD="$DB_PASSWORD" psql \
-    -h "$DB_HOST" -p "${DB_PORT:-5432}" -U "$DB_USER" -d "$DB_NAME" \
-    -c "SELECT COUNT(*) FROM dashboard_templates WHERE user_id IS NULL OR user_id = ''"
+psql -c "SELECT COUNT(*) FROM dashboard_templates WHERE user_id IS NULL OR user_id = ''"
+
+# Verify JSON columns are populated
+psql -c "SELECT COUNT(*) FROM dashboard_templates WHERE sm IS NOT NULL AND sm::text != '[]'"
 ```
 
 ```bash
 exit
 ```
 
-### 15.2 Via GABI (if available for widget-layout-backend)
+### 15.2 Via GABI (not available for widget-layout-backend in staging)
 
-If you have a GABI instance for widget-layout-backend:
+GABI is not yet configured for widget-layout-backend. Debug-container psql verification (15.1) is sufficient.
+
+If GABI becomes available in the future:
 
 ```bash
 TOKEN="sha256~<your-token>"
@@ -453,12 +483,9 @@ curl -H "Authorization: Bearer $TOKEN" "$GABI/query" \
     -d '{"query": "SELECT COUNT(*) FROM dashboard_templates"}' -s | jq
 ```
 
-### 15.3 Via the Widget-Layout API (if deployed in stage)
+### 15.3 Via the Widget-Layout API (not available in staging)
 
-```bash
-curl -H "x-rh-identity: <base64-encoded-identity>" \
-    https://<stage-api>/api/widget-layout/v1/
-```
+The `widget-layout-backend-stage` namespace has no external Route. This verification method is not available in staging. Skip to cleanup.
 
 ---
 
@@ -466,9 +493,11 @@ curl -H "x-rh-identity: <base64-encoded-identity>" \
 
 ### 16.1 Delete Debug-Containers
 
+The debug-container is a Deployment — delete the Deployment, not just the pod (deleting the pod alone causes the Deployment to recreate it):
+
 ```bash
-oc -n chrome-service-stage delete pod debug-container
-oc -n widget-layout-backend-stage delete pod debug-container
+oc -n chrome-service-stage delete deployment debug-container
+oc -n widget-layout-backend-stage delete deployment debug-container
 ```
 
 ### 16.2 Clean Up Local Files
@@ -501,11 +530,9 @@ The migration script wraps all INSERTs in a `BEGIN`/`COMMIT` transaction. If any
 If the data was imported but needs to be removed:
 
 ```bash
-oc -n widget-layout-backend-stage exec -it debug-container -- bash
+oc -n widget-layout-backend-stage exec -it "$TARGET_POD" -- bash
 
-PGPASSWORD="$DB_PASSWORD" psql \
-    -h "$DB_HOST" -p "${DB_PORT:-5432}" -U "$DB_USER" -d "$DB_NAME" \
-    -c "DELETE FROM dashboard_templates WHERE created_at < '2026-05-08'"
+psql -c "DELETE FROM dashboard_templates WHERE created_at < '2026-05-08'"
 ```
 
 Adjust the `WHERE` clause to target only the migrated rows. Use timestamps or other identifying criteria to avoid deleting post-migration data.

--- a/docs/chrome-data-migration/MIGRATION_STAGING.md
+++ b/docs/chrome-data-migration/MIGRATION_STAGING.md
@@ -75,6 +75,8 @@ The two databases use different schemas for the same conceptual table. The migra
 | `updated_at` (timestamp) | `updated_at` (timestamp) | Direct copy |
 | `deleted_at` (timestamp) | `deleted_at` (timestamp) | Direct copy |
 
+> **Note on `x`/`y` vs `cx`/`cy` coordinates:** The widget grid items stored in the `sm`/`md`/`lg`/`xl` JSONB columns use `x`/`y` keys. The widget-layout-backend API also uses `x`/`y` at runtime. The `cx`/`cy` naming is only required in YAML configuration files (ConfigMaps, env vars) because YAML parsers treat bare `y` as a boolean. Since this migration copies JSONB directly between PostgreSQL databases — never passing through a YAML parser — no coordinate key renaming is needed.
+
 ---
 
 ## 4. Step 1: Obtain Staging Access (app-interface MR)

--- a/docs/chrome-data-migration/MIGRATION_STAGING.md
+++ b/docs/chrome-data-migration/MIGRATION_STAGING.md
@@ -1,0 +1,544 @@
+# Widget Dashboard Templates Migration Plan (Staging)
+
+Migrate the `dashboard_templates` table from chrome-service DB to widget-layout-backend DB in staging.
+
+---
+
+## Table of Contents
+
+1. [Overview](#1-overview)
+2. [Prerequisites](#2-prerequisites)
+3. [Schema Translation](#3-schema-translation)
+4. [Step 1: Obtain Staging Access (app-interface MR)](#4-step-1-obtain-staging-access-app-interface-mr)
+5. [Step 2: Wait for MR Merge and Reconciliation](#5-step-2-wait-for-mr-merge-and-reconciliation)
+6. [Step 3: Log In to the Cluster](#6-step-3-log-in-to-the-cluster)
+7. [Step 4: Verify Namespace Access](#7-step-4-verify-namespace-access)
+8. [Step 5: Launch Debug-Container in Chrome-Service Namespace (Source)](#8-step-5-launch-debug-container-in-chrome-service-namespace-source)
+9. [Step 6: Export Data from Chrome-Service DB](#9-step-6-export-data-from-chrome-service-db)
+10. [Step 7: Transfer Files to Local Machine](#10-step-7-transfer-files-to-local-machine)
+11. [Step 8: Launch Debug-Container in Widget-Layout Namespace (Target)](#11-step-8-launch-debug-container-in-widget-layout-namespace-target)
+12. [Step 9: Transfer Files to Target Debug-Container](#12-step-9-transfer-files-to-target-debug-container)
+13. [Step 10: Review the Generated SQL](#13-step-10-review-the-generated-sql)
+14. [Step 11: Import Data into Widget-Layout DB](#14-step-11-import-data-into-widget-layout-db)
+15. [Step 12: Verify the Migration](#15-step-12-verify-the-migration)
+16. [Step 13: Clean Up](#16-step-13-clean-up)
+17. [Rollback Procedure](#17-rollback-procedure)
+18. [Reference](#18-reference)
+
+---
+
+## 1. Overview
+
+| Item | Detail |
+|------|--------|
+| **Source DB** | chrome-service PostgreSQL (stage) |
+| **Target DB** | widget-layout-backend PostgreSQL (stage) |
+| **Source table** | `dashboard_templates` (chrome-service) |
+| **Target table** | `dashboard_templates` (widget-layout-backend) |
+| **Cluster** | `crcs02ue1` — both namespaces are on the same cluster |
+| **Source namespace** | `chrome-service-stage` |
+| **Target namespace** | `widget-layout-backend-stage` |
+| **Source DB secret** | `chrome-service-db` (output_resource_name in app-interface) |
+| **Target DB secret** | `widget-layout-backend-db` (output_resource_name in app-interface) |
+| **Method** | Python script using `psycopg2` inside debug-containers |
+| **Migration script** | `widget-migration-script.py` |
+| **Authorized users** | tefaz, khala, bflorkie, mmarosi |
+
+---
+
+## 2. Prerequisites
+
+- `oc` CLI installed locally
+- Access to the `crcs02ue1` OpenShift cluster console
+- The staging access MR merged (see Step 1)
+- The migration script `widget-migration-script.py` available locally
+
+---
+
+## 3. Schema Translation
+
+The two databases use different schemas for the same conceptual table. The migration script handles these translations automatically:
+
+| Chrome-Service Column | Widget-Layout Column | Translation |
+|-----------------------|----------------------|-------------|
+| `id` (uint, PK) | `id` (uint, PK) | Auto-generated in target (not copied) |
+| `user_identity_id` (uint, FK) | `user_id` (string) | JOIN `user_identities` table to resolve `account_id` |
+| _(does not exist)_ | `dashboard_name` (string) | Copied from `display_name` |
+| `default` (bool) | `default` (bool) | Direct copy |
+| `name` (string, embedded) | `name` (string, embedded) | Direct copy |
+| `display_name` (string, embedded) | `display_name` (string, embedded) | Direct copy |
+| `sm` (JSON) | `sm` (JSON) | Direct copy |
+| `md` (JSON) | `md` (JSON) | Direct copy |
+| `lg` (JSON) | `lg` (JSON) | Direct copy |
+| `xl` (JSON) | `xl` (JSON) | Direct copy |
+| `created_at` (timestamp) | `created_at` (timestamp) | Direct copy |
+| `updated_at` (timestamp) | `updated_at` (timestamp) | Direct copy |
+| `deleted_at` (timestamp) | `deleted_at` (timestamp) | Direct copy |
+
+---
+
+## 4. Step 1: Obtain Staging Access (app-interface MR)
+
+The `platform-experience` and `platform-experience-services` roles only grant `view` access to the staging namespaces. To run debug-containers (which requires pod create/exec and indirect secret access), a temporary `edit-no-secrets` role is needed.
+
+### 1.1 Create the Role File
+
+File: `data/teams/insights/roles/platform-experience-staging-dev.yml`
+
+```yaml
+---
+
+$schema: /access/role-1.yml
+
+labels: {}
+name: platform-experience-staging-dev
+
+description: |
+  Temporary staging write access for dashboard_templates data migration
+  from chrome-service to widget-layout-backend.
+
+permissions: []
+
+expirationDate: '2026-06-08'
+
+access:
+- namespace:
+    $ref: /services/insights/chrome-service/namespaces/chrome-service-stage.yml
+  clusterRole: edit-no-secrets
+- namespace:
+    $ref: /services/insights/widget-layout-backend/namespaces/crcs02ue1-widget-layout-backend-stage.yml
+  clusterRole: edit-no-secrets
+```
+
+Key details:
+- `edit-no-secrets` grants pod create/exec but **not** direct secret read
+- DB credentials are accessed indirectly via the debug-container pod mounting the secret
+- `expirationDate` is set to 1 month out (2026-06-08); adjust as needed
+- Both namespaces are on `crcs02ue1` cluster
+
+### 1.2 Add Role to User Files
+
+Add the following line to the `roles:` section of each user file in `data/teams/insights/users/`:
+
+```yaml
+- $ref: /teams/insights/roles/platform-experience-staging-dev.yml
+```
+
+Users to update:
+- `tefaz.yml`
+- `khala.yml`
+- `bflorkie.yml`
+- `mmarosi.yml`
+
+### 1.3 Commit and Push
+
+```bash
+cd /path/to/app-interface
+git fetch upstream master
+git checkout -b widget-migration-staging-dev upstream/master
+# ... make the changes above ...
+git add data/teams/insights/roles/platform-experience-staging-dev.yml \
+        data/teams/insights/users/tefaz.yml \
+        data/teams/insights/users/khala.yml \
+        data/teams/insights/users/bflorkie.yml \
+        data/teams/insights/users/mmarosi.yml
+git commit -m "Add staging dev role for widget migration"
+git push origin widget-migration-staging-dev
+```
+
+### 1.4 Create Merge Request
+
+Open the MR link provided by git push output. Target: `service/app-interface` master branch.
+
+**Status: MR created and pushed to `origin/widget-migration-staging-dev`.**
+
+---
+
+## 5. Step 2: Wait for MR Merge and Reconciliation
+
+1. Get MR reviewed and approved
+2. Once merged, wait for `qontract-reconcile` to apply the RBAC changes to the cluster
+3. This typically takes 5-15 minutes after merge
+4. You can monitor by checking if your new role is visible:
+   ```bash
+   oc auth can-i create pods -n chrome-service-stage
+   ```
+   Should return `yes` once reconciliation is complete.
+
+---
+
+## 6. Step 3: Log In to the Cluster
+
+1. Navigate to the `crcs02ue1` cluster console:
+   ```
+   https://console-openshift-console.apps.crcs02ue1.urby.p1.openshiftapps.com
+   ```
+
+2. Click your username (top right) -> **Copy login command** -> **Display Token**
+
+3. Copy the `oc login` command and run it in your terminal:
+   ```bash
+   oc login --token=sha256~<your-token> --server=https://api.crcs02ue1.urby.p1.openshiftapps.com:6443
+   ```
+
+4. Verify login:
+   ```bash
+   oc whoami
+   ```
+   Should show your username.
+
+---
+
+## 7. Step 4: Verify Namespace Access
+
+Confirm you have the required permissions in both namespaces:
+
+```bash
+# Check chrome-service-stage
+oc auth can-i create pods -n chrome-service-stage
+# Expected: yes
+
+oc auth can-i create pods/exec -n chrome-service-stage
+# Expected: yes
+
+# Check widget-layout-backend-stage
+oc auth can-i create pods -n widget-layout-backend-stage
+# Expected: yes
+
+oc auth can-i create pods/exec -n widget-layout-backend-stage
+# Expected: yes
+```
+
+If any return `no`, the RBAC hasn't reconciled yet. Wait a few more minutes and retry.
+
+---
+
+## 8. Step 5: Launch Debug-Container in Chrome-Service Namespace (Source)
+
+The debug-container template mounts the DB secret as environment variables inside the pod.
+
+```bash
+oc process --local \
+    -f https://raw.githubusercontent.com/app-sre/container-images/master/debug-container/openshift.yml \
+    -p POSTGRES_DB_SECRET_NAME="chrome-service-db" \
+| oc -n chrome-service-stage apply -f -
+```
+
+Wait for the pod to be ready:
+
+```bash
+oc -n chrome-service-stage get pod debug-container -w
+```
+
+Wait until `STATUS` shows `Running`. Press `Ctrl+C` to stop watching.
+
+---
+
+## 9. Step 6: Export Data from Chrome-Service DB
+
+### 9.1 Copy the Migration Script into the Debug-Container
+
+```bash
+oc -n chrome-service-stage cp ./widget-migration-script.py debug-container:/tmp/widget-migration-script.py
+```
+
+### 9.2 Exec into the Debug-Container
+
+```bash
+oc -n chrome-service-stage exec -it debug-container -- bash
+```
+
+### 9.3 Verify DB Connectivity
+
+Inside the container, the DB secret is available as environment variables. Test the connection:
+
+```bash
+echo "Host: $DB_HOST"
+echo "User: $DB_USER"
+echo "DB:   $DB_NAME"
+echo "Port: ${DB_PORT:-5432}"
+
+PGPASSWORD="$DB_PASSWORD" psql \
+    -h "$DB_HOST" -p "${DB_PORT:-5432}" -U "$DB_USER" -d "$DB_NAME" \
+    -c "SELECT COUNT(*) FROM dashboard_templates"
+```
+
+You should see a row count. If this fails, verify the secret name is correct:
+```bash
+env | grep DB_
+```
+
+### 9.4 Run the Export
+
+```bash
+python3 /tmp/widget-migration-script.py export
+```
+
+This will:
+- Query `dashboard_templates` JOIN `user_identities` from chrome-service DB
+- Translate `user_identity_id` (uint FK) to `user_id` (string account_id)
+- Copy `display_name` to `dashboard_name`
+- Generate `/tmp/widget_migration.sql` with INSERT statements wrapped in a transaction
+
+Expected output:
+```
+Found N active dashboard_templates rows
+Fetched N rows (with user_id resolved)
+Generated N INSERT statements in /tmp/widget_migration.sql
+```
+
+### 9.5 Quick Review Inside the Container
+
+```bash
+head -20 /tmp/widget_migration.sql
+wc -l /tmp/widget_migration.sql
+```
+
+### 9.6 Exit the Container
+
+```bash
+exit
+```
+
+---
+
+## 10. Step 7: Transfer Files to Local Machine
+
+Copy the generated SQL and the migration script from the source debug-container to your local machine:
+
+```bash
+oc -n chrome-service-stage cp debug-container:/tmp/widget_migration.sql ./widget_migration.sql
+```
+
+Verify the file was copied:
+
+```bash
+head -20 ./widget_migration.sql
+grep -c "^INSERT" ./widget_migration.sql
+```
+
+---
+
+## 11. Step 8: Launch Debug-Container in Widget-Layout Namespace (Target)
+
+```bash
+oc process --local \
+    -f https://raw.githubusercontent.com/app-sre/container-images/master/debug-container/openshift.yml \
+    -p POSTGRES_DB_SECRET_NAME="widget-layout-backend-db" \
+| oc -n widget-layout-backend-stage apply -f -
+```
+
+Wait for the pod to be ready:
+
+```bash
+oc -n widget-layout-backend-stage get pod debug-container -w
+```
+
+Wait until `STATUS` shows `Running`. Press `Ctrl+C` to stop watching.
+
+---
+
+## 12. Step 9: Transfer Files to Target Debug-Container
+
+```bash
+oc -n widget-layout-backend-stage cp ./widget_migration.sql debug-container:/tmp/widget_migration.sql
+oc -n widget-layout-backend-stage cp ./widget-migration-script.py debug-container:/tmp/widget-migration-script.py
+```
+
+---
+
+## 13. Step 10: Review the Generated SQL
+
+Before importing, review the SQL to ensure correctness.
+
+```bash
+oc -n widget-layout-backend-stage exec -it debug-container -- bash
+```
+
+Inside the container:
+
+```bash
+# Check first few INSERT statements
+head -30 /tmp/widget_migration.sql
+
+# Count total inserts
+grep -c "^INSERT" /tmp/widget_migration.sql
+
+# Check for any NULL user_ids (would indicate failed JOIN)
+grep "VALUES (NULL" /tmp/widget_migration.sql || echo "No NULL user_ids - good"
+
+# Exit for now
+exit
+```
+
+---
+
+## 14. Step 11: Import Data into Widget-Layout DB
+
+### 14.1 Exec into the Target Debug-Container
+
+```bash
+oc -n widget-layout-backend-stage exec -it debug-container -- bash
+```
+
+### 14.2 Verify Target DB Connectivity
+
+```bash
+echo "Host: $DB_HOST"
+echo "User: $DB_USER"
+echo "DB:   $DB_NAME"
+
+PGPASSWORD="$DB_PASSWORD" psql \
+    -h "$DB_HOST" -p "${DB_PORT:-5432}" -U "$DB_USER" -d "$DB_NAME" \
+    -c "SELECT COUNT(*) FROM dashboard_templates"
+```
+
+Note the current row count (should be 0 or whatever exists before migration).
+
+### 14.3 Run the Import
+
+```bash
+python3 /tmp/widget-migration-script.py import
+```
+
+The script will:
+1. Show the number of INSERT statements found
+2. Ask for confirmation: `Proceed with import? (y/N):`
+3. Type `y` and press Enter
+4. Execute all INSERTs inside a transaction (auto-rollback on any error)
+5. Print the final row count in the target table
+
+Expected output:
+```
+Found N INSERT statements in /tmp/widget_migration.sql
+Proceed with import? (y/N): y
+Running import...
+Target DB now has N dashboard_templates rows
+Done.
+```
+
+### 14.4 Exit the Container
+
+```bash
+exit
+```
+
+---
+
+## 15. Step 12: Verify the Migration
+
+### 15.1 Via Debug-Container
+
+```bash
+oc -n widget-layout-backend-stage exec -it debug-container -- bash
+```
+
+```bash
+# Total count
+PGPASSWORD="$DB_PASSWORD" psql \
+    -h "$DB_HOST" -p "${DB_PORT:-5432}" -U "$DB_USER" -d "$DB_NAME" \
+    -c "SELECT COUNT(*) FROM dashboard_templates"
+
+# Sample a few rows
+PGPASSWORD="$DB_PASSWORD" psql \
+    -h "$DB_HOST" -p "${DB_PORT:-5432}" -U "$DB_USER" -d "$DB_NAME" \
+    -c "SELECT id, user_id, dashboard_name, name, display_name, \"default\" FROM dashboard_templates LIMIT 5"
+
+# Check user_id is populated (should return 0)
+PGPASSWORD="$DB_PASSWORD" psql \
+    -h "$DB_HOST" -p "${DB_PORT:-5432}" -U "$DB_USER" -d "$DB_NAME" \
+    -c "SELECT COUNT(*) FROM dashboard_templates WHERE user_id IS NULL OR user_id = ''"
+```
+
+```bash
+exit
+```
+
+### 15.2 Via GABI (if available for widget-layout-backend)
+
+If you have a GABI instance for widget-layout-backend:
+
+```bash
+TOKEN="sha256~<your-token>"
+GABI="https://<widget-layout-gabi-endpoint>"
+
+curl -H "Authorization: Bearer $TOKEN" "$GABI/query" \
+    -d '{"query": "SELECT COUNT(*) FROM dashboard_templates"}' -s | jq
+```
+
+### 15.3 Via the Widget-Layout API (if deployed in stage)
+
+```bash
+curl -H "x-rh-identity: <base64-encoded-identity>" \
+    https://<stage-api>/api/widget-layout/v1/
+```
+
+---
+
+## 16. Step 13: Clean Up
+
+### 16.1 Delete Debug-Containers
+
+```bash
+oc -n chrome-service-stage delete pod debug-container
+oc -n widget-layout-backend-stage delete pod debug-container
+```
+
+### 16.2 Clean Up Local Files
+
+```bash
+rm ./widget_migration.sql
+```
+
+### 16.3 Remove Staging Dev Role (after migration is verified)
+
+Once the migration is confirmed successful and the role is no longer needed, submit an MR to:
+
+1. Remove `- $ref: /teams/insights/roles/platform-experience-staging-dev.yml` from all 4 user files
+2. Delete `data/teams/insights/roles/platform-experience-staging-dev.yml`
+
+Or simply let it expire on `2026-06-08`.
+
+---
+
+## 17. Rollback Procedure
+
+If something goes wrong during import:
+
+### Automatic Rollback
+
+The migration script wraps all INSERTs in a `BEGIN`/`COMMIT` transaction. If any INSERT fails, the entire transaction is rolled back automatically. No partial data will be written.
+
+### Manual Rollback (after successful import)
+
+If the data was imported but needs to be removed:
+
+```bash
+oc -n widget-layout-backend-stage exec -it debug-container -- bash
+
+PGPASSWORD="$DB_PASSWORD" psql \
+    -h "$DB_HOST" -p "${DB_PORT:-5432}" -U "$DB_USER" -d "$DB_NAME" \
+    -c "DELETE FROM dashboard_templates WHERE created_at < '2026-05-08'"
+```
+
+Adjust the `WHERE` clause to target only the migrated rows. Use timestamps or other identifying criteria to avoid deleting post-migration data.
+
+---
+
+## 18. Reference
+
+| Resource | Location |
+|----------|----------|
+| Migration script | `widget-migration-script.py` (local) |
+| Access MR branch | `widget-migration-staging-dev` |
+| Role file | `data/teams/insights/roles/platform-experience-staging-dev.yml` |
+| Debug-container docs | `docs/app-sre/sops/general/debug-container.md` |
+| Self-SRE access docs | `docs/platform-users/access/self-sre-openshift-access.md` |
+| DB connection docs | `docs/platform-users/external-resources/aws/rds/connect-to-postgres-mysql-database.md` |
+| Chrome-service namespace | `data/services/insights/chrome-service/namespaces/chrome-service-stage.yml` |
+| Widget-layout namespace | `data/services/insights/widget-layout-backend/namespaces/crcs02ue1-widget-layout-backend-stage.yml` |
+| Chrome-service DB secret name | `chrome-service-db` |
+| Widget-layout DB secret name | `widget-layout-backend-db` |
+| Cluster | `crcs02ue1` |
+| Cluster console | `https://console-openshift-console.apps.crcs02ue1.urby.p1.openshiftapps.com` |
+| JIRA ticket | RHCLOUD-40883 |

--- a/docs/chrome-data-migration/MIGRATION_STAGING.md
+++ b/docs/chrome-data-migration/MIGRATION_STAGING.md
@@ -248,22 +248,22 @@ oc -n chrome-service-stage cp ./widget-migration-script.py debug-container:/tmp/
 oc -n chrome-service-stage exec -it debug-container -- bash
 ```
 
-### 9.3 Verify DB Connectivity
-
-Inside the container, the DB secret is available as environment variables. Test the connection:
+### 9.3 Run Preflight Check
 
 ```bash
-echo "Host: $DB_HOST"
-echo "User: $DB_USER"
-echo "DB:   $DB_NAME"
-echo "Port: ${DB_PORT:-5432}"
-
-PGPASSWORD="$DB_PASSWORD" psql \
-    -h "$DB_HOST" -p "${DB_PORT:-5432}" -U "$DB_USER" -d "$DB_NAME" \
-    -c "SELECT COUNT(*) FROM dashboard_templates"
+python3 /tmp/widget-migration-script.py preflight-export
 ```
 
-You should see a row count. If this fails, verify the secret name is correct:
+This checks:
+- DB connectivity and SELECT permissions
+- Active row count in `dashboard_templates`
+- Orphaned rows (no matching `user_identity`) — these will be dropped by the JOIN
+- Users with NULL/empty `account_id` — these would produce NULL `user_id` in target
+- Total exportable rows after JOIN
+
+All checks must show `[PASS]`. If any show `[FAIL]`, investigate before proceeding.
+
+If the DB secret is not mounted correctly:
 ```bash
 env | grep DB_
 ```
@@ -347,27 +347,26 @@ oc -n widget-layout-backend-stage cp ./widget-migration-script.py debug-containe
 
 ---
 
-## 13. Step 10: Review the Generated SQL
-
-Before importing, review the SQL to ensure correctness.
+## 13. Step 10: Run Preflight Check on Target DB
 
 ```bash
 oc -n widget-layout-backend-stage exec -it debug-container -- bash
 ```
 
-Inside the container:
+```bash
+python3 /tmp/widget-migration-script.py preflight-import
+```
+
+This checks:
+- DB connectivity and `dashboard_templates` table exists
+- All expected columns present (`user_id`, `dashboard_name`, `sm`, `md`, `lg`, `xl`, etc.)
+- INSERT permission (inserts a test row and rolls back)
+- Target table is empty (warns about duplicate risk if not)
+- SQL file exists and has INSERT statements
+
+All checks must show `[PASS]`. If any show `[FAIL]`, investigate before proceeding.
 
 ```bash
-# Check first few INSERT statements
-head -30 /tmp/widget_migration.sql
-
-# Count total inserts
-grep -c "^INSERT" /tmp/widget_migration.sql
-
-# Check for any NULL user_ids (would indicate failed JOIN)
-grep "VALUES (NULL" /tmp/widget_migration.sql || echo "No NULL user_ids - good"
-
-# Exit for now
 exit
 ```
 
@@ -381,21 +380,7 @@ exit
 oc -n widget-layout-backend-stage exec -it debug-container -- bash
 ```
 
-### 14.2 Verify Target DB Connectivity
-
-```bash
-echo "Host: $DB_HOST"
-echo "User: $DB_USER"
-echo "DB:   $DB_NAME"
-
-PGPASSWORD="$DB_PASSWORD" psql \
-    -h "$DB_HOST" -p "${DB_PORT:-5432}" -U "$DB_USER" -d "$DB_NAME" \
-    -c "SELECT COUNT(*) FROM dashboard_templates"
-```
-
-Note the current row count (should be 0 or whatever exists before migration).
-
-### 14.3 Run the Import
+### 14.2 Run the Import
 
 ```bash
 python3 /tmp/widget-migration-script.py import

--- a/docs/chrome-data-migration/MIGRATION_STAGING.md
+++ b/docs/chrome-data-migration/MIGRATION_STAGING.md
@@ -81,7 +81,7 @@ The two databases use different schemas for the same conceptual table. The migra
 
 ## 4. Step 1: Obtain Staging Access (app-interface MR)
 
-The `platform-experience` and `platform-experience-services` roles only grant `view` access to the staging namespaces. To run debug-containers (which requires pod create/exec and indirect secret access), a temporary `edit-no-secrets` role is needed.
+The `platform-experience` and `platform-experience-services` roles only grant `view` access to the staging namespaces. To run debug-containers (which requires pod create/exec), a temporary `edit` role is needed.
 
 ### 1.1 Create the Role File
 
@@ -101,19 +101,19 @@ description: |
 
 permissions: []
 
-expirationDate: '2026-06-08'
+expirationDate: '2026-06-10'
 
 access:
 - namespace:
     $ref: /services/insights/chrome-service/namespaces/chrome-service-stage.yml
-  clusterRole: edit-no-secrets
+  clusterRole: edit
 - namespace:
     $ref: /services/insights/widget-layout-backend/namespaces/crcs02ue1-widget-layout-backend-stage.yml
-  clusterRole: edit-no-secrets
+  clusterRole: edit
 ```
 
 Key details:
-- `edit-no-secrets` grants pod create/exec but **not** direct secret read
+- `edit` grants pod create/exec (and secret read, which is acceptable for staging)
 - DB credentials are accessed indirectly via the debug-container pod mounting the secret
 - `expirationDate` is set to 1 month out (2026-06-08); adjust as needed
 - Both namespaces are on `crcs02ue1` cluster

--- a/docs/chrome-data-migration/widget-migration-script.py
+++ b/docs/chrome-data-migration/widget-migration-script.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""
+Widget Data Migration Script
+Migrates dashboard_templates from chrome-service DB to widget-layout-backend DB.
+
+Schema translation:
+  chrome-service.user_identity_id (uint FK) -> widget-layout.user_id (string)
+    resolved via JOIN on user_identities.account_id
+  chrome-service.display_name -> widget-layout.dashboard_name (copy)
+
+Usage:
+  1. Copy this script into chrome-service debug-container
+  2. Run: python3 widget-migration-script.py export
+  3. Copy /tmp/widget_migration.sql out, then into widget-layout debug-container
+  4. Run: python3 widget-migration-script.py import
+"""
+
+import json
+import os
+import sys
+
+import psycopg2
+import psycopg2.extras
+
+OUTPUT_FILE = "/tmp/widget_migration.sql"
+
+
+def get_connection():
+    required = ["DB_HOST", "DB_USER", "DB_PASSWORD", "DB_NAME"]
+    missing = [v for v in required if not os.environ.get(v)]
+    if missing:
+        print(f"ERROR: Missing env vars: {', '.join(missing)}")
+        print("Is the DB secret mounted?")
+        sys.exit(1)
+
+    return psycopg2.connect(
+        host=os.environ["DB_HOST"],
+        port=os.environ.get("DB_PORT", "5432"),
+        user=os.environ["DB_USER"],
+        password=os.environ["DB_PASSWORD"],
+        dbname=os.environ["DB_NAME"],
+    )
+
+
+def sql_value(val):
+    if val is None:
+        return "NULL"
+    if isinstance(val, bool):
+        return "true" if val else "false"
+    if isinstance(val, (dict, list)):
+        return "'" + json.dumps(val).replace("'", "''") + "'::jsonb"
+    s = str(val).replace("'", "''")
+    return f"'{s}'"
+
+
+def do_export():
+    conn = get_connection()
+    cur = conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor)
+
+    cur.execute("SELECT COUNT(*) as cnt FROM dashboard_templates WHERE deleted_at IS NULL")
+    total = cur.fetchone()["cnt"]
+    print(f"Found {total} active dashboard_templates rows")
+
+    if total == 0:
+        print("No records to migrate.")
+        return
+
+    cur.execute("""
+        SELECT
+            ui.account_id AS user_id,
+            dt.display_name AS dashboard_name,
+            dt."default",
+            dt.name,
+            dt.display_name,
+            dt.sm,
+            dt.md,
+            dt.lg,
+            dt.xl,
+            dt.created_at,
+            dt.updated_at,
+            dt.deleted_at
+        FROM dashboard_templates dt
+        JOIN user_identities ui ON dt.user_identity_id = ui.id
+    """)
+
+    rows = cur.fetchall()
+    print(f"Fetched {len(rows)} rows (with user_id resolved)")
+
+    with open(OUTPUT_FILE, "w") as f:
+        f.write("-- Widget Migration: chrome-service -> widget-layout-backend\n")
+        f.write("-- Auto-generated. Review before running.\n\n")
+        f.write("BEGIN;\n\n")
+
+        for row in rows:
+            cols = "user_id, dashboard_name, \"default\", name, display_name, sm, md, lg, xl, created_at, updated_at, deleted_at"
+            vals = ", ".join([
+                sql_value(row["user_id"]),
+                sql_value(row["dashboard_name"]),
+                sql_value(row["default"]),
+                sql_value(row["name"]),
+                sql_value(row["display_name"]),
+                sql_value(row["sm"]),
+                sql_value(row["md"]),
+                sql_value(row["lg"]),
+                sql_value(row["xl"]),
+                sql_value(row["created_at"]),
+                sql_value(row["updated_at"]),
+                sql_value(row["deleted_at"]),
+            ])
+            f.write(f"INSERT INTO dashboard_templates ({cols})\nVALUES ({vals});\n\n")
+
+        f.write("COMMIT;\n")
+
+    insert_count = sum(1 for line in open(OUTPUT_FILE) if line.startswith("INSERT"))
+    print(f"Generated {insert_count} INSERT statements in {OUTPUT_FILE}")
+    print()
+    print("Next steps:")
+    print(f"  1. Review {OUTPUT_FILE}")
+    print(f"  2. Copy out: oc -n chrome-service-stage cp debug-container:{OUTPUT_FILE} ./widget_migration.sql")
+    print(f"  3. Copy in:  oc -n widget-layout-backend-stage cp ./widget_migration.sql debug-container:{OUTPUT_FILE}")
+    print(f"  4. Run import: python3 widget-migration-script.py import")
+
+    cur.close()
+    conn.close()
+
+
+def do_import():
+    if not os.path.exists(OUTPUT_FILE):
+        print(f"ERROR: {OUTPUT_FILE} not found.")
+        print("Copy it from the export debug-container first.")
+        sys.exit(1)
+
+    with open(OUTPUT_FILE) as f:
+        sql = f.read()
+
+    insert_count = sql.count("INSERT INTO")
+    print(f"Found {insert_count} INSERT statements in {OUTPUT_FILE}")
+
+    confirm = input("Proceed with import? (y/N): ").strip().lower()
+    if confirm != "y":
+        print("Aborted.")
+        return
+
+    conn = get_connection()
+    cur = conn.cursor()
+
+    print("Running import...")
+    cur.execute(sql)
+    conn.commit()
+
+    cur.execute("SELECT COUNT(*) FROM dashboard_templates")
+    count = cur.fetchone()[0]
+    print(f"Target DB now has {count} dashboard_templates rows")
+    print("Done.")
+
+    cur.close()
+    conn.close()
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2 or sys.argv[1] not in ("export", "import"):
+        print("Usage: python3 widget-migration-script.py <export|import>")
+        print()
+        print("  export  - Run inside chrome-service debug-container")
+        print("            Generates SQL file from source DB")
+        print()
+        print("  import  - Run inside widget-layout-backend debug-container")
+        print("            Executes SQL file against target DB")
+        sys.exit(1)
+
+    if sys.argv[1] == "export":
+        do_export()
+    else:
+        do_import()

--- a/docs/chrome-data-migration/widget-migration-script.py
+++ b/docs/chrome-data-migration/widget-migration-script.py
@@ -246,10 +246,21 @@ def do_export():
             dt.deleted_at
         FROM dashboard_templates dt
         JOIN user_identities ui ON dt.user_identity_id = ui.id
+        WHERE dt.deleted_at IS NULL
     """)
 
     rows = cur.fetchall()
     print(f"Fetched {len(rows)} rows (with user_id resolved)")
+
+    bad_rows = [r for r in rows if not r["user_id"]]
+    if bad_rows:
+        print(f"ERROR: {len(bad_rows)} rows have NULL/empty user_id:")
+        for r in bad_rows:
+            print(f"  name={r['name']}, display_name={r['display_name']}")
+        print("Aborting — fix user_identities data before retrying.")
+        cur.close()
+        conn.close()
+        sys.exit(1)
 
     with open(OUTPUT_FILE, "w") as f:
         f.write("-- Widget Migration: chrome-service -> widget-layout-backend\n")
@@ -283,7 +294,7 @@ def do_export():
     print(f"  1. Review {OUTPUT_FILE}")
     print(f"  2. Copy out: oc -n chrome-service-stage cp debug-container:{OUTPUT_FILE} ./widget_migration.sql")
     print(f"  3. Copy in:  oc -n widget-layout-backend-stage cp ./widget_migration.sql debug-container:{OUTPUT_FILE}")
-    print(f"  4. Run import: python3 widget-migration-script.py import")
+    print("  4. Run import: python3 widget-migration-script.py import")
 
     cur.close()
     conn.close()
@@ -310,8 +321,15 @@ def do_import():
     cur = conn.cursor()
 
     print("Running import...")
-    cur.execute(sql)
-    conn.commit()
+    try:
+        cur.execute(sql)
+        conn.commit()
+    except psycopg2.Error as e:
+        conn.rollback()
+        print(f"ERROR: Import failed, transaction rolled back: {e}")
+        cur.close()
+        conn.close()
+        sys.exit(1)
 
     cur.execute("SELECT COUNT(*) FROM dashboard_templates")
     count = cur.fetchone()[0]

--- a/docs/chrome-data-migration/widget-migration-script.py
+++ b/docs/chrome-data-migration/widget-migration-script.py
@@ -10,9 +10,11 @@ Schema translation:
 
 Usage:
   1. Copy this script into chrome-service debug-container
-  2. Run: python3 widget-migration-script.py export
-  3. Copy /tmp/widget_migration.sql out, then into widget-layout debug-container
-  4. Run: python3 widget-migration-script.py import
+  2. Run: python3 widget-migration-script.py preflight-export
+  3. Run: python3 widget-migration-script.py export
+  4. Copy /tmp/widget_migration.sql out, then into widget-layout debug-container
+  5. Run: python3 widget-migration-script.py preflight-import
+  6. Run: python3 widget-migration-script.py import
 """
 
 import json
@@ -51,6 +53,169 @@ def sql_value(val):
         return "'" + json.dumps(val).replace("'", "''") + "'::jsonb"
     s = str(val).replace("'", "''")
     return f"'{s}'"
+
+
+def check(label, ok, detail=""):
+    status = "PASS" if ok else "FAIL"
+    msg = f"  [{status}] {label}"
+    if detail:
+        msg += f" — {detail}"
+    print(msg)
+    return ok
+
+
+def do_preflight_export():
+    print("=== Preflight: Source DB (chrome-service) ===\n")
+    all_ok = True
+
+    # 1. Connectivity
+    try:
+        conn = get_connection()
+        cur = conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor)
+        all_ok &= check("DB connectivity", True)
+    except Exception as e:
+        check("DB connectivity", False, str(e))
+        sys.exit(1)
+
+    # 2. SELECT permission on dashboard_templates
+    try:
+        cur.execute("SELECT COUNT(*) as cnt FROM dashboard_templates")
+        total = cur.fetchone()["cnt"]
+        all_ok &= check("SELECT on dashboard_templates", True, f"{total} total rows")
+    except Exception as e:
+        all_ok &= check("SELECT on dashboard_templates", False, str(e))
+        cur.close()
+        conn.close()
+        print(f"\n{'READY' if all_ok else 'NOT READY'} for export.")
+        sys.exit(0 if all_ok else 1)
+
+    # 3. SELECT permission on user_identities
+    try:
+        cur.execute("SELECT COUNT(*) as cnt FROM user_identities")
+        ui_total = cur.fetchone()["cnt"]
+        all_ok &= check("SELECT on user_identities", True, f"{ui_total} total rows")
+    except Exception as e:
+        all_ok &= check("SELECT on user_identities", False, str(e))
+
+    # 4. Active (non-deleted) rows
+    cur.execute("SELECT COUNT(*) as cnt FROM dashboard_templates WHERE deleted_at IS NULL")
+    active = cur.fetchone()["cnt"]
+    all_ok &= check("Active dashboard_templates", active > 0, f"{active} rows (deleted_at IS NULL)")
+
+    # 5. Orphaned rows (no matching user_identity)
+    cur.execute("""
+        SELECT COUNT(*) as cnt FROM dashboard_templates dt
+        LEFT JOIN user_identities ui ON dt.user_identity_id = ui.id
+        WHERE ui.id IS NULL
+    """)
+    orphaned = cur.fetchone()["cnt"]
+    all_ok &= check("Orphaned rows (no user_identity)", orphaned == 0,
+                     f"{orphaned} rows will be dropped by JOIN" if orphaned > 0 else "none")
+
+    # 6. Users with NULL/empty account_id
+    cur.execute("""
+        SELECT COUNT(*) as cnt FROM dashboard_templates dt
+        JOIN user_identities ui ON dt.user_identity_id = ui.id
+        WHERE ui.account_id IS NULL OR ui.account_id = ''
+    """)
+    null_acct = cur.fetchone()["cnt"]
+    all_ok &= check("NULL/empty account_id", null_acct == 0,
+                     f"{null_acct} rows would get NULL user_id in target" if null_acct > 0 else "none")
+
+    # 7. Row count after JOIN (what export will actually produce)
+    cur.execute("""
+        SELECT COUNT(*) as cnt FROM dashboard_templates dt
+        JOIN user_identities ui ON dt.user_identity_id = ui.id
+    """)
+    join_count = cur.fetchone()["cnt"]
+    all_ok &= check("Exportable rows (after JOIN)", join_count > 0, f"{join_count} rows")
+
+    cur.close()
+    conn.close()
+
+    print(f"\n{'READY' if all_ok else 'NOT READY'} for export.")
+    if not all_ok:
+        sys.exit(1)
+
+
+def do_preflight_import():
+    print("=== Preflight: Target DB (widget-layout-backend) ===\n")
+    all_ok = True
+
+    # 1. Connectivity
+    try:
+        conn = get_connection()
+        cur = conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor)
+        all_ok &= check("DB connectivity", True)
+    except Exception as e:
+        check("DB connectivity", False, str(e))
+        sys.exit(1)
+
+    # 2. dashboard_templates table exists
+    try:
+        cur.execute("""
+            SELECT COUNT(*) as cnt FROM information_schema.tables
+            WHERE table_schema = 'public' AND table_name = 'dashboard_templates'
+        """)
+        exists = cur.fetchone()["cnt"] > 0
+        all_ok &= check("dashboard_templates table exists", exists)
+    except Exception as e:
+        all_ok &= check("dashboard_templates table exists", False, str(e))
+
+    # 3. Expected columns exist
+    expected_cols = {"user_id", "dashboard_name", "default", "name", "display_name",
+                     "sm", "md", "lg", "xl", "created_at", "updated_at", "deleted_at"}
+    try:
+        cur.execute("""
+            SELECT column_name FROM information_schema.columns
+            WHERE table_schema = 'public' AND table_name = 'dashboard_templates'
+        """)
+        actual_cols = {row["column_name"] for row in cur.fetchall()}
+        missing = expected_cols - actual_cols
+        all_ok &= check("Expected columns present", len(missing) == 0,
+                         f"missing: {', '.join(sorted(missing))}" if missing else "all found")
+    except Exception as e:
+        all_ok &= check("Expected columns present", False, str(e))
+
+    # 4. INSERT permission (dry test)
+    try:
+        cur.execute("BEGIN")
+        cur.execute("""
+            INSERT INTO dashboard_templates (user_id, dashboard_name, "default", name, display_name, sm, md, lg, xl)
+            VALUES ('__preflight_test__', '__test__', false, '__test__', '__test__', '[]'::jsonb, '[]'::jsonb, '[]'::jsonb, '[]'::jsonb)
+        """)
+        conn.rollback()
+        all_ok &= check("INSERT permission", True, "test row inserted and rolled back")
+    except Exception as e:
+        conn.rollback()
+        all_ok &= check("INSERT permission", False, str(e))
+
+    # 5. Current row count (duplicate risk)
+    try:
+        cur.execute("SELECT COUNT(*) as cnt FROM dashboard_templates")
+        existing = cur.fetchone()["cnt"]
+        if existing > 0:
+            all_ok &= check("Target table empty", False, f"{existing} rows already exist — risk of duplicates")
+        else:
+            all_ok &= check("Target table empty", True, "0 rows")
+    except Exception as e:
+        all_ok &= check("Target table empty", False, str(e))
+
+    # 6. SQL file exists
+    sql_exists = os.path.exists(OUTPUT_FILE)
+    if sql_exists:
+        with open(OUTPUT_FILE) as f:
+            insert_count = f.read().count("INSERT INTO")
+        all_ok &= check(f"SQL file exists ({OUTPUT_FILE})", True, f"{insert_count} INSERT statements")
+    else:
+        all_ok &= check(f"SQL file exists ({OUTPUT_FILE})", False, "copy it from source debug-container first")
+
+    cur.close()
+    conn.close()
+
+    print(f"\n{'READY' if all_ok else 'NOT READY'} for import.")
+    if not all_ok:
+        sys.exit(1)
 
 
 def do_export():
@@ -158,17 +323,29 @@ def do_import():
 
 
 if __name__ == "__main__":
-    if len(sys.argv) != 2 or sys.argv[1] not in ("export", "import"):
-        print("Usage: python3 widget-migration-script.py <export|import>")
+    commands = ("preflight-export", "preflight-import", "export", "import")
+    if len(sys.argv) != 2 or sys.argv[1] not in commands:
+        print("Usage: python3 widget-migration-script.py <command>")
         print()
-        print("  export  - Run inside chrome-service debug-container")
-        print("            Generates SQL file from source DB")
+        print("  preflight-export  - Run inside chrome-service debug-container")
+        print("                      Checks connectivity, permissions, data quality")
         print()
-        print("  import  - Run inside widget-layout-backend debug-container")
-        print("            Executes SQL file against target DB")
+        print("  preflight-import  - Run inside widget-layout-backend debug-container")
+        print("                      Checks connectivity, permissions, schema, target state")
+        print()
+        print("  export            - Run inside chrome-service debug-container")
+        print("                      Generates SQL file from source DB")
+        print()
+        print("  import            - Run inside widget-layout-backend debug-container")
+        print("                      Executes SQL file against target DB")
         sys.exit(1)
 
-    if sys.argv[1] == "export":
+    cmd = sys.argv[1]
+    if cmd == "preflight-export":
+        do_preflight_export()
+    elif cmd == "preflight-import":
+        do_preflight_import()
+    elif cmd == "export":
         do_export()
     else:
         do_import()

--- a/docs/chrome-data-migration/widget-migration-script.py
+++ b/docs/chrome-data-migration/widget-migration-script.py
@@ -269,6 +269,23 @@ def do_export():
     rows = cur.fetchall()
     print(f"Fetched {len(rows)} rows (with user_id resolved)")
 
+    # Chrome-service uses bare names (e.g., "landingPage").
+    # Widget-layout uses "{frontendRef}-{name}" (e.g., "landing-landingPage").
+    NAME_MAP = {
+        "landingPage": "landing-landingPage",
+    }
+    unmapped = set()
+    for row in rows:
+        original = row["name"]
+        if original in NAME_MAP:
+            row["name"] = NAME_MAP[original]
+        else:
+            unmapped.add(original)
+    if unmapped:
+        print(f"ERROR: {len(unmapped)} unmapped name values: {unmapped}")
+        print("Add these to NAME_MAP before proceeding.")
+        sys.exit(1)
+
     bad_rows = [r for r in rows if not r["user_id"]]
     if bad_rows:
         print(f"ERROR: {len(bad_rows)} rows have NULL/empty user_id:")

--- a/docs/chrome-data-migration/widget-migration-script.py
+++ b/docs/chrome-data-migration/widget-migration-script.py
@@ -28,19 +28,35 @@ OUTPUT_FILE = "/tmp/widget_migration.sql"
 
 
 def get_connection():
-    required = ["DB_HOST", "DB_USER", "DB_PASSWORD", "DB_NAME"]
-    missing = [v for v in required if not os.environ.get(v)]
+    # Debug-containers mount secrets as PG* vars; the script originally used DB_*.
+    # Accept both formats: try PG* first (debug-container default), fall back to DB_*.
+    host = os.environ.get("PGHOST") or os.environ.get("DB_HOST")
+    port = os.environ.get("PGPORT") or os.environ.get("DB_PORT", "5432")
+    user = os.environ.get("PGUSER") or os.environ.get("DB_USER")
+    password = os.environ.get("PGPASSWORD") or os.environ.get("DB_PASSWORD")
+    dbname = os.environ.get("PGDATABASE") or os.environ.get("DB_NAME")
+
+    missing = []
+    if not host:
+        missing.append("PGHOST/DB_HOST")
+    if not user:
+        missing.append("PGUSER/DB_USER")
+    if not password:
+        missing.append("PGPASSWORD/DB_PASSWORD")
+    if not dbname:
+        missing.append("PGDATABASE/DB_NAME")
+
     if missing:
         print(f"ERROR: Missing env vars: {', '.join(missing)}")
-        print("Is the DB secret mounted?")
+        print("Is the DB secret mounted? Run: env | grep -E 'PG|DB_'")
         sys.exit(1)
 
     return psycopg2.connect(
-        host=os.environ["DB_HOST"],
-        port=os.environ.get("DB_PORT", "5432"),
-        user=os.environ["DB_USER"],
-        password=os.environ["DB_PASSWORD"],
-        dbname=os.environ["DB_NAME"],
+        host=host,
+        port=port,
+        user=user,
+        password=password,
+        dbname=dbname,
     )
 
 

--- a/docs/chrome-data-migration/widget-migration-script.py
+++ b/docs/chrome-data-migration/widget-migration-script.py
@@ -326,8 +326,8 @@ def do_export():
     print()
     print("Next steps:")
     print(f"  1. Review {OUTPUT_FILE}")
-    print(f"  2. Copy out: oc -n chrome-service-stage cp debug-container:{OUTPUT_FILE} ./widget_migration.sql")
-    print(f"  3. Copy in:  oc -n widget-layout-backend-stage cp ./widget_migration.sql debug-container:{OUTPUT_FILE}")
+    print(f"  2. Copy out: oc cp <source-pod>:{OUTPUT_FILE} ./widget_migration.sql")
+    print(f"  3. Copy in:  oc cp ./widget_migration.sql <target-pod>:{OUTPUT_FILE}")
     print("  4. Run import: python3 widget-migration-script.py import")
 
     cur.close()

--- a/docs/chrome-data-migration/widget-migration-script.py
+++ b/docs/chrome-data-migration/widget-migration-script.py
@@ -102,21 +102,21 @@ def do_preflight_export():
     active = cur.fetchone()["cnt"]
     all_ok &= check("Active dashboard_templates", active > 0, f"{active} rows (deleted_at IS NULL)")
 
-    # 5. Orphaned rows (no matching user_identity)
+    # 5. Orphaned active rows (no matching user_identity)
     cur.execute("""
         SELECT COUNT(*) as cnt FROM dashboard_templates dt
         LEFT JOIN user_identities ui ON dt.user_identity_id = ui.id
-        WHERE ui.id IS NULL
+        WHERE dt.deleted_at IS NULL AND ui.id IS NULL
     """)
     orphaned = cur.fetchone()["cnt"]
     all_ok &= check("Orphaned rows (no user_identity)", orphaned == 0,
-                     f"{orphaned} rows will be dropped by JOIN" if orphaned > 0 else "none")
+                     f"{orphaned} active rows will be dropped by JOIN" if orphaned > 0 else "none")
 
-    # 6. Users with NULL/empty account_id
+    # 6. Active users with NULL/empty account_id
     cur.execute("""
         SELECT COUNT(*) as cnt FROM dashboard_templates dt
         JOIN user_identities ui ON dt.user_identity_id = ui.id
-        WHERE ui.account_id IS NULL OR ui.account_id = ''
+        WHERE dt.deleted_at IS NULL AND (ui.account_id IS NULL OR ui.account_id = '')
     """)
     null_acct = cur.fetchone()["cnt"]
     all_ok &= check("NULL/empty account_id", null_acct == 0,
@@ -126,6 +126,7 @@ def do_preflight_export():
     cur.execute("""
         SELECT COUNT(*) as cnt FROM dashboard_templates dt
         JOIN user_identities ui ON dt.user_identity_id = ui.id
+        WHERE dt.deleted_at IS NULL
     """)
     join_count = cur.fetchone()["cnt"]
     all_ok &= check("Exportable rows (after JOIN)", join_count > 0, f"{join_count} rows")
@@ -181,8 +182,8 @@ def do_preflight_import():
     try:
         cur.execute("BEGIN")
         cur.execute("""
-            INSERT INTO dashboard_templates (user_id, dashboard_name, "default", name, display_name, sm, md, lg, xl)
-            VALUES ('__preflight_test__', '__test__', false, '__test__', '__test__', '[]'::jsonb, '[]'::jsonb, '[]'::jsonb, '[]'::jsonb)
+            INSERT INTO dashboard_templates (user_id, dashboard_name, "default", name, display_name, sm, md, lg, xl, created_at, updated_at, deleted_at)
+            VALUES ('__preflight_test__', '__test__', false, '__test__', '__test__', '[]'::jsonb, '[]'::jsonb, '[]'::jsonb, '[]'::jsonb, NOW(), NOW(), NULL)
         """)
         conn.rollback()
         all_ok &= check("INSERT permission", True, "test row inserted and rolled back")


### PR DESCRIPTION
## Summary
- Add staging and production migration plans for migrating `dashboard_templates` data from chrome-service DB to widget-layout-backend DB
- Add Python migration script (`widget-migration-script.py`) that handles schema translation:
  - `user_identity_id` (uint FK) → `user_id` (string account_id) via JOIN on `user_identities`
  - `display_name` → `dashboard_name`
- All files placed in `docs/chrome-data-migration/`

## Test plan
- [x] Data translation script tested locally against both databases
- [x] Seeded chrome-service DB with 3 test users and dashboard templates
- [x] Export: verified user_id resolution, dashboard_name mapping, JSONB grid item preservation
- [x] Import: verified 3 rows inserted via transaction into widget-layout DB
- [x] Verification: confirmed all fields match between source and target (user_id as string, dashboard_name populated, JSONB arrays intact)

🤖 Generated with [Claude Code](https://claude.com/claude-code)