### PR TITLE
fix(RHCLOUD-47878): transform widget item IDs during data migration and adding data integrity check

### DIFF
--- a/docs/chrome-data-migration/MIGRATION_PROD.md
+++ b/docs/chrome-data-migration/MIGRATION_PROD.md
@@ -400,15 +400,28 @@ exit
 
 ## 10. Step 7: Transfer Files to Local Machine
 
+> **WARNING:** `oc cp` and `oc exec cat > file` can silently truncate large files (~9.5MB+). Use the base64 method below to ensure complete transfer. See "Lessons Learned" in `MIGRATION_STAGING.md` for details.
+
+Transfer the SQL and metadata files from the source debug-container:
+
 ```bash
-oc -n chrome-service-prod cp "$SOURCE_POD:/tmp/widget_migration.sql" ./widget_migration_prod.sql
+# Transfer SQL file via base64 (reliable for large files)
+oc -n chrome-service-prod exec "$SOURCE_POD" -- base64 /tmp/widget_migration.sql > ./widget_migration_prod.sql.b64
+base64 -D -i ./widget_migration_prod.sql.b64 -o ./widget_migration_prod.sql
+rm ./widget_migration_prod.sql.b64
+
+# Transfer metadata file (small, plain copy is fine)
+oc -n chrome-service-prod exec "$SOURCE_POD" -- cat /tmp/widget_migration.meta > ./widget_migration_prod.meta
 ```
 
-Verify the file was copied:
+> **Note:** On Linux, use `base64 -d` instead of `base64 -D`.
+
+Verify the file was transferred completely:
 
 ```bash
-head -20 ./widget_migration_prod.sql
 grep -c "^INSERT" ./widget_migration_prod.sql
+cat ./widget_migration_prod.meta
+# INSERT count must match the count in the .meta file
 ```
 
 **Recommended:** Compare prod row count with staging to ensure they are in the expected ratio. If prod has significantly fewer or more rows than expected, investigate.
@@ -439,8 +452,23 @@ echo "Target pod: $TARGET_POD"
 ## 12. Step 9: Transfer Files to Target Debug-Container
 
 ```bash
-oc -n widget-layout-backend-prod cp ./widget_migration_prod.sql "$TARGET_POD:/tmp/widget_migration.sql"
-oc -n widget-layout-backend-prod cp ./widget-migration-script.py "$TARGET_POD:/tmp/widget-migration-script.py"
+# Transfer SQL file via base64 (reliable for large files)
+base64 -i ./widget_migration_prod.sql | oc -n widget-layout-backend-prod exec -i "$TARGET_POD" -- bash -c 'base64 -d > /tmp/widget_migration.sql'
+
+# Transfer metadata file
+cat ./widget_migration_prod.meta | oc -n widget-layout-backend-prod exec -i "$TARGET_POD" -- bash -c 'cat > /tmp/widget_migration.meta'
+
+# Transfer migration script
+cat ./widget-migration-script.py | oc -n widget-layout-backend-prod exec -i "$TARGET_POD" -- bash -c 'cat > /tmp/widget-migration-script.py'
+```
+
+> **Note:** On Linux, use `base64` (no `-i` flag) instead of `base64 -i`.
+
+Verify INSERT count on the target pod:
+
+```bash
+oc -n widget-layout-backend-prod exec "$TARGET_POD" -- grep -c "^INSERT" /tmp/widget_migration.sql
+# Must match the count from the export step
 ```
 
 ---
@@ -495,9 +523,15 @@ oc -n widget-layout-backend-prod exec -it "$TARGET_POD" -- bash
 python3 /tmp/widget-migration-script.py import
 ```
 
+Or skip the interactive confirmation prompt:
+
+```bash
+python3 /tmp/widget-migration-script.py import --yes
+```
+
 The script will:
 1. Show the number of INSERT statements found
-2. Ask for confirmation: `Proceed with import? (y/N):`
+2. Ask for confirmation (unless `--yes` is passed): `Proceed with import? (y/N):`
 3. **Double-check the count matches your export count before typing `y`**
 4. Type `y` and press Enter
 5. Execute all INSERTs inside a transaction (auto-rollback on any error)
@@ -600,7 +634,7 @@ oc -n widget-layout-backend-prod get deployment debug-container 2>&1 | grep "not
 ### 16.2 Clean Up Local Files
 
 ```bash
-rm ./widget_migration_prod.sql
+rm ./widget_migration_prod.sql ./widget_migration_prod.meta
 ```
 
 ### 16.3 Remove Breakglass Role

--- a/docs/chrome-data-migration/MIGRATION_PROD.md
+++ b/docs/chrome-data-migration/MIGRATION_PROD.md
@@ -84,15 +84,17 @@ Same as staging. The migration script handles these translations automatically:
 | `default` (bool) | `default` (bool) | Direct copy |
 | `name` (string, embedded) | `name` (string, embedded) | Translated via NAME_MAP (e.g., `landingPage` → `landing-landingPage`) |
 | `display_name` (string, embedded) | `display_name` (string, embedded) | Direct copy |
-| `sm` (JSON) | `sm` (JSON) | Direct copy |
-| `md` (JSON) | `md` (JSON) | Direct copy |
-| `lg` (JSON) | `lg` (JSON) | Direct copy |
-| `xl` (JSON) | `xl` (JSON) | Direct copy |
+| `sm` (JSON) | `sm` (JSON) | Widget item `"i"` fields transformed via WIDGET_ID_MAP (e.g., `rhel#rhel` → `landing-./RhelWidget`) |
+| `md` (JSON) | `md` (JSON) | Widget item `"i"` fields transformed via WIDGET_ID_MAP |
+| `lg` (JSON) | `lg` (JSON) | Widget item `"i"` fields transformed via WIDGET_ID_MAP |
+| `xl` (JSON) | `xl` (JSON) | Widget item `"i"` fields transformed via WIDGET_ID_MAP |
 | `created_at` (timestamp) | `created_at` (timestamp) | Direct copy |
 | `updated_at` (timestamp) | `updated_at` (timestamp) | Direct copy |
 | `deleted_at` (timestamp) | `deleted_at` (timestamp) | Direct copy |
 
 > **Note on `x`/`y` vs `cx`/`cy` coordinates:** The widget grid items stored in the `sm`/`md`/`lg`/`xl` JSONB columns use `x`/`y` keys. The widget-layout-backend API also uses `x`/`y` at runtime. The `cx`/`cy` naming is only required in YAML configuration files (ConfigMaps, env vars) because YAML parsers treat bare `y` as a boolean. Since this migration copies JSONB directly between PostgreSQL databases — never passing through a YAML parser — no coordinate key renaming is needed.
+>
+> **Note on widget item `"i"` field transformation:** Chrome-service stores widget item identifiers in `"shortKey#shortKey"` format (e.g., `"rhel#rhel"`), while widget-layout-backend uses `"{scope}-{module}"` format (e.g., `"landing-./RhelWidget"`). The migration script transforms these via `WIDGET_ID_MAP` during export. The full mapping is documented in `docs/WIDGET_MIGRATION.md`.
 
 ---
 
@@ -368,6 +370,7 @@ Expected output:
 ```
 Found N active dashboard_templates rows
 Fetched N rows (with user_id resolved)
+Transformed widget IDs in JSONB columns (sm/md/lg/xl)
 Generated N INSERT statements in /tmp/widget_migration.sql
 ```
 
@@ -542,6 +545,12 @@ psql -c "SELECT COUNT(*) FROM dashboard_templates WHERE dashboard_name != displa
 
 # Verify JSON columns are populated
 psql -c "SELECT COUNT(*) FROM dashboard_templates WHERE sm IS NOT NULL AND sm::text != '[]'"
+
+# Verify widget IDs are in FEO format (should show "landing-./RhelWidget" etc., not "rhel#rhel")
+psql -c "SELECT id, sm->0->>'i' AS first_widget_id FROM dashboard_templates LIMIT 5"
+
+# Confirm no old-format IDs remain (should return 0)
+psql -c "SELECT COUNT(*) FROM dashboard_templates WHERE sm::text LIKE '%#%'"
 ```
 
 ```bash

--- a/docs/chrome-data-migration/MIGRATION_PROD.md
+++ b/docs/chrome-data-migration/MIGRATION_PROD.md
@@ -547,10 +547,10 @@ psql -c "SELECT COUNT(*) FROM dashboard_templates WHERE dashboard_name != displa
 psql -c "SELECT COUNT(*) FROM dashboard_templates WHERE sm IS NOT NULL AND sm::text != '[]'"
 
 # Verify widget IDs are in FEO format (should show "landing-./RhelWidget" etc., not "rhel#rhel")
-psql -c "SELECT id, sm->0->>'i' AS first_widget_id FROM dashboard_templates LIMIT 5"
+psql -c "SELECT id, sm->0->>'i' AS sm_first, md->0->>'i' AS md_first, lg->0->>'i' AS lg_first, xl->0->>'i' AS xl_first FROM dashboard_templates LIMIT 5"
 
-# Confirm no old-format IDs remain (should return 0)
-psql -c "SELECT COUNT(*) FROM dashboard_templates WHERE sm::text LIKE '%#%'"
+# Confirm no old-format IDs remain in any JSONB column (should return 0)
+psql -c "SELECT COUNT(*) FROM dashboard_templates WHERE sm::text LIKE '%#%' OR md::text LIKE '%#%' OR lg::text LIKE '%#%' OR xl::text LIKE '%#%'"
 ```
 
 ```bash

--- a/docs/chrome-data-migration/MIGRATION_STAGING.md
+++ b/docs/chrome-data-migration/MIGRATION_STAGING.md
@@ -71,6 +71,8 @@ These issues were encountered during the first staging migration. The instructio
 
 6. **Widget item `"i"` fields must be transformed during migration**: Chrome-service stores widget item identifiers in `"shortKey#shortKey"` format (e.g., `"rhel#rhel"`), while widget-layout-backend uses `"{scope}-{module}"` format (e.g., `"landing-./RhelWidget"`). The migration script handles this via `WIDGET_ID_MAP` during export. Without this transformation, the frontend cannot match template items to widget definitions from the `/widget-mapping` endpoint.
 
+7. **`oc cp` and pipe-based transfers silently truncate large files**: The exported SQL file can be ~9.5MB. `oc cp` may fail with `unexpected EOF`, and the fallback `oc exec cat > file` silently truncates the output with no error (e.g., 1362 of 1903 rows transferred). Use base64 encoding for reliable transfers. The migration script now writes a `.meta` file with the expected INSERT count so `preflight-import` can detect truncation automatically.
+
 ---
 
 ## 3. Schema Translation
@@ -332,17 +334,28 @@ exit
 
 ## 10. Step 7: Transfer Files to Local Machine
 
-Copy the generated SQL from the source debug-container to your local machine:
+> **WARNING:** `oc cp` and `oc exec cat > file` can silently truncate large files (~9.5MB+). Use the base64 method below to ensure complete transfer.
+
+Transfer the SQL and metadata files from the source debug-container:
 
 ```bash
-oc -n chrome-service-stage cp "$SOURCE_POD:/tmp/widget_migration.sql" ./widget_migration.sql
+# Transfer SQL file via base64 (reliable for large files)
+oc -n chrome-service-stage exec "$SOURCE_POD" -- base64 /tmp/widget_migration.sql > ./widget_migration.sql.b64
+base64 -D -i ./widget_migration.sql.b64 -o ./widget_migration.sql
+rm ./widget_migration.sql.b64
+
+# Transfer metadata file (small, plain copy is fine)
+oc -n chrome-service-stage exec "$SOURCE_POD" -- cat /tmp/widget_migration.meta > ./widget_migration.meta
 ```
 
-Verify the file was copied:
+> **Note:** On Linux, use `base64 -d` instead of `base64 -D`.
+
+Verify the file was transferred completely:
 
 ```bash
-head -20 ./widget_migration.sql
 grep -c "^INSERT" ./widget_migration.sql
+cat ./widget_migration.meta
+# INSERT count must match the count in the .meta file
 ```
 
 ---
@@ -371,8 +384,23 @@ echo "Target pod: $TARGET_POD"
 ## 12. Step 9: Transfer Files to Target Debug-Container
 
 ```bash
-oc -n widget-layout-backend-stage cp ./widget_migration.sql "$TARGET_POD:/tmp/widget_migration.sql"
-oc -n widget-layout-backend-stage cp ./widget-migration-script.py "$TARGET_POD:/tmp/widget-migration-script.py"
+# Transfer SQL file via base64 (reliable for large files)
+base64 -i ./widget_migration.sql | oc -n widget-layout-backend-stage exec -i "$TARGET_POD" -- bash -c 'base64 -d > /tmp/widget_migration.sql'
+
+# Transfer metadata file
+cat ./widget_migration.meta | oc -n widget-layout-backend-stage exec -i "$TARGET_POD" -- bash -c 'cat > /tmp/widget_migration.meta'
+
+# Transfer migration script
+cat ./widget-migration-script.py | oc -n widget-layout-backend-stage exec -i "$TARGET_POD" -- bash -c 'cat > /tmp/widget-migration-script.py'
+```
+
+> **Note:** On Linux, use `base64` (no `-i` flag) instead of `base64 -i`.
+
+Verify INSERT count on the target pod:
+
+```bash
+oc -n widget-layout-backend-stage exec "$TARGET_POD" -- grep -c "^INSERT" /tmp/widget_migration.sql
+# Must match the count from the export step
 ```
 
 ---
@@ -423,9 +451,15 @@ oc -n widget-layout-backend-stage exec -it "$TARGET_POD" -- bash
 python3 /tmp/widget-migration-script.py import
 ```
 
+Or skip the interactive confirmation prompt:
+
+```bash
+python3 /tmp/widget-migration-script.py import --yes
+```
+
 The script will:
 1. Show the number of INSERT statements found
-2. Ask for confirmation: `Proceed with import? (y/N):`
+2. Ask for confirmation (unless `--yes` is passed): `Proceed with import? (y/N):`
 3. Type `y` and press Enter
 4. Execute all INSERTs inside a transaction (auto-rollback on any error)
 5. Print the final row count in the target table
@@ -515,7 +549,7 @@ oc -n widget-layout-backend-stage delete deployment debug-container
 ### 16.2 Clean Up Local Files
 
 ```bash
-rm ./widget_migration.sql
+rm ./widget_migration.sql ./widget_migration.meta
 ```
 
 ### 16.3 Remove Staging Dev Role (after migration is verified)

--- a/docs/chrome-data-migration/MIGRATION_STAGING.md
+++ b/docs/chrome-data-migration/MIGRATION_STAGING.md
@@ -69,6 +69,8 @@ These issues were encountered during the first staging migration. The instructio
 
 5. **`psql` reads PG* vars natively**: Inside the debug-container, you can run `psql` without `-h`/`-U`/`-d` flags — it picks up `PGHOST`, `PGUSER`, `PGPASSWORD`, `PGDATABASE` automatically.
 
+6. **Widget item `"i"` fields must be transformed during migration**: Chrome-service stores widget item identifiers in `"shortKey#shortKey"` format (e.g., `"rhel#rhel"`), while widget-layout-backend uses `"{scope}-{module}"` format (e.g., `"landing-./RhelWidget"`). The migration script handles this via `WIDGET_ID_MAP` during export. Without this transformation, the frontend cannot match template items to widget definitions from the `/widget-mapping` endpoint.
+
 ---
 
 ## 3. Schema Translation
@@ -83,15 +85,17 @@ The two databases use different schemas for the same conceptual table. The migra
 | `default` (bool) | `default` (bool) | Direct copy |
 | `name` (string, embedded) | `name` (string, embedded) | Translated via NAME_MAP (e.g., `landingPage` → `landing-landingPage`) |
 | `display_name` (string, embedded) | `display_name` (string, embedded) | Direct copy |
-| `sm` (JSON) | `sm` (JSON) | Direct copy |
-| `md` (JSON) | `md` (JSON) | Direct copy |
-| `lg` (JSON) | `lg` (JSON) | Direct copy |
-| `xl` (JSON) | `xl` (JSON) | Direct copy |
+| `sm` (JSON) | `sm` (JSON) | Widget item `"i"` fields transformed via WIDGET_ID_MAP (e.g., `rhel#rhel` → `landing-./RhelWidget`) |
+| `md` (JSON) | `md` (JSON) | Widget item `"i"` fields transformed via WIDGET_ID_MAP |
+| `lg` (JSON) | `lg` (JSON) | Widget item `"i"` fields transformed via WIDGET_ID_MAP |
+| `xl` (JSON) | `xl` (JSON) | Widget item `"i"` fields transformed via WIDGET_ID_MAP |
 | `created_at` (timestamp) | `created_at` (timestamp) | Direct copy |
 | `updated_at` (timestamp) | `updated_at` (timestamp) | Direct copy |
 | `deleted_at` (timestamp) | `deleted_at` (timestamp) | Direct copy |
 
 > **Note on `x`/`y` vs `cx`/`cy` coordinates:** The widget grid items stored in the `sm`/`md`/`lg`/`xl` JSONB columns use `x`/`y` keys. The widget-layout-backend API also uses `x`/`y` at runtime. The `cx`/`cy` naming is only required in YAML configuration files (ConfigMaps, env vars) because YAML parsers treat bare `y` as a boolean. Since this migration copies JSONB directly between PostgreSQL databases — never passing through a YAML parser — no coordinate key renaming is needed.
+>
+> **Note on widget item `"i"` field transformation:** Chrome-service stores widget item identifiers in `"shortKey#shortKey"` format (e.g., `"rhel#rhel"`), while widget-layout-backend uses `"{scope}-{module}"` format (e.g., `"landing-./RhelWidget"`). The migration script transforms these via `WIDGET_ID_MAP` during export. The full mapping is documented in `docs/WIDGET_MIGRATION.md`.
 
 ---
 
@@ -300,12 +304,14 @@ This will:
 - Query `dashboard_templates` JOIN `user_identities` from chrome-service DB
 - Translate `user_identity_id` (uint FK) to `user_id` (string account_id)
 - Copy `display_name` to `dashboard_name`
+- Transform widget item `"i"` fields in JSONB columns from chrome-service format (e.g., `"rhel#rhel"`) to FEO format (e.g., `"landing-./RhelWidget"`)
 - Generate `/tmp/widget_migration.sql` with INSERT statements wrapped in a transaction
 
 Expected output:
 ```
 Found N active dashboard_templates rows
 Fetched N rows (with user_id resolved)
+Transformed widget IDs in JSONB columns (sm/md/lg/xl)
 Generated N INSERT statements in /tmp/widget_migration.sql
 ```
 
@@ -463,6 +469,12 @@ psql -c "SELECT COUNT(*) FROM dashboard_templates WHERE user_id IS NULL OR user_
 
 # Verify JSON columns are populated
 psql -c "SELECT COUNT(*) FROM dashboard_templates WHERE sm IS NOT NULL AND sm::text != '[]'"
+
+# Verify widget IDs are in FEO format (should show "landing-./RhelWidget" etc., not "rhel#rhel")
+psql -c "SELECT id, sm->0->>'i' AS first_widget_id FROM dashboard_templates LIMIT 5"
+
+# Confirm no old-format IDs remain (should return 0)
+psql -c "SELECT COUNT(*) FROM dashboard_templates WHERE sm::text LIKE '%#%'"
 ```
 
 ```bash

--- a/docs/chrome-data-migration/MIGRATION_STAGING.md
+++ b/docs/chrome-data-migration/MIGRATION_STAGING.md
@@ -471,10 +471,10 @@ psql -c "SELECT COUNT(*) FROM dashboard_templates WHERE user_id IS NULL OR user_
 psql -c "SELECT COUNT(*) FROM dashboard_templates WHERE sm IS NOT NULL AND sm::text != '[]'"
 
 # Verify widget IDs are in FEO format (should show "landing-./RhelWidget" etc., not "rhel#rhel")
-psql -c "SELECT id, sm->0->>'i' AS first_widget_id FROM dashboard_templates LIMIT 5"
+psql -c "SELECT id, sm->0->>'i' AS sm_first, md->0->>'i' AS md_first, lg->0->>'i' AS lg_first, xl->0->>'i' AS xl_first FROM dashboard_templates LIMIT 5"
 
-# Confirm no old-format IDs remain (should return 0)
-psql -c "SELECT COUNT(*) FROM dashboard_templates WHERE sm::text LIKE '%#%'"
+# Confirm no old-format IDs remain in any JSONB column (should return 0)
+psql -c "SELECT COUNT(*) FROM dashboard_templates WHERE sm::text LIKE '%#%' OR md::text LIKE '%#%' OR lg::text LIKE '%#%' OR xl::text LIKE '%#%'"
 ```
 
 ```bash

--- a/docs/chrome-data-migration/widget-migration-script.py
+++ b/docs/chrome-data-migration/widget-migration-script.py
@@ -110,8 +110,11 @@ def transform_widget_ids(items):
         if not isinstance(item, dict) or "i" not in item:
             continue
         raw_id = item["i"]
+        if not isinstance(raw_id, str):
+            print(f"  WARNING: skipping non-string widget ID: {raw_id!r} (type={type(raw_id).__name__})")
+            continue
         # Strip "#suffix" if present (chrome-service uses "key#key" format)
-        short_key = raw_id.split("#")[0]
+        short_key = raw_id.split("#", 1)[0]
         if short_key in WIDGET_ID_MAP:
             item["i"] = WIDGET_ID_MAP[short_key]
         else:
@@ -347,7 +350,7 @@ def do_export():
         cur.close()
         conn.close()
         sys.exit(1)
-    print(f"Transformed widget IDs in JSONB columns (sm/md/lg/xl)")
+    print("Transformed widget IDs in JSONB columns (sm/md/lg/xl)")
 
     bad_rows = [r for r in rows if not r["user_id"]]
     if bad_rows:

--- a/docs/chrome-data-migration/widget-migration-script.py
+++ b/docs/chrome-data-migration/widget-migration-script.py
@@ -282,10 +282,16 @@ def do_preflight_import():
     # 7. Cross-check against export metadata (catches truncated file transfers)
     meta_exists = os.path.exists(META_FILE)
     if meta_exists and sql_exists:
+        found_insert_count = False
         with open(META_FILE) as f:
             for line in f:
                 if line.startswith("INSERT_COUNT="):
-                    expected = int(line.strip().split("=", 1)[1])
+                    found_insert_count = True
+                    try:
+                        expected = int(line.strip().split("=", 1)[1])
+                    except ValueError:
+                        all_ok &= check("INSERT count matches export", False, "invalid INSERT_COUNT value in meta file")
+                        break
                     match = insert_count == expected
                     all_ok &= check(
                         "INSERT count matches export",
@@ -293,6 +299,8 @@ def do_preflight_import():
                         f"expected {expected}, got {insert_count} — file may be truncated" if not match else f"{insert_count} matches",
                     )
                     break
+        if not found_insert_count:
+            all_ok &= check("INSERT count matches export", False, "INSERT_COUNT missing in meta file")
     elif sql_exists:
         check(f"Meta file ({META_FILE})", False, "not found — copy it alongside the SQL file to enable integrity check")
 

--- a/docs/chrome-data-migration/widget-migration-script.py
+++ b/docs/chrome-data-migration/widget-migration-script.py
@@ -7,6 +7,8 @@ Schema translation:
   chrome-service.user_identity_id (uint FK) -> widget-layout.user_id (string)
     resolved via JOIN on user_identities.account_id
   chrome-service.display_name -> widget-layout.dashboard_name (copy)
+  chrome-service.sm/md/lg/xl JSONB "i" fields -> widget-layout FEO widget IDs
+    e.g., "rhel#rhel" -> "landing-./RhelWidget" (see WIDGET_ID_MAP)
 
 Usage:
   1. Copy this script into chrome-service debug-container
@@ -25,6 +27,29 @@ import psycopg2
 import psycopg2.extras
 
 OUTPUT_FILE = "/tmp/widget_migration.sql"
+
+# Chrome-service widget IDs -> widget-layout-backend FEO widget IDs.
+# Source: docs/WIDGET_MIGRATION.md
+# Chrome-service stores "i" values as "shortKey#shortKey" (e.g., "rhel#rhel").
+# Widget-layout-backend expects "{scope}-{module}" (e.g., "landing-./RhelWidget").
+WIDGET_ID_MAP = {
+    "acs":                 "landing-./AcsWidget",
+    "ansible":             "landing-./AnsibleWidget",
+    "edge":                "landing-./EdgeWidget",
+    "exploreCapabilities": "landing-./ExploreCapabilities",
+    "favoriteServices":    "chrome-./DashboardFavorites",
+    "imageBuilder":        "landing-./ImageBuilderWidget",
+    "integrations":        "sources-./IntegrationsWidget",
+    "learningResources":   "learningResources-./BookmarkedLearningResourcesWidget",
+    "notificationsEvents": "notifications-./DashboardWidget",
+    "openshift":           "landing-./OpenShiftWidget",
+    "openshiftAi":         "landing-./OpenShiftAiWidget",
+    "quay":                "landing-./QuayWidget",
+    "recentlyVisited":     "landing-./RecentlyVisited",
+    "rhel":                "landing-./RhelWidget",
+    "subscriptions":       "subscriptionInventory-./SubscriptionsWidget",
+    "supportCases":        "landing-./SupportCaseWidget",
+}
 
 
 def get_connection():
@@ -69,6 +94,29 @@ def sql_value(val):
         return "'" + json.dumps(val).replace("'", "''") + "'::jsonb"
     s = str(val).replace("'", "''")
     return f"'{s}'"
+
+
+def transform_widget_ids(items):
+    """Transform widget item "i" fields from chrome-service to widget-layout format.
+
+    Chrome-service format: "shortKey#shortKey" (e.g., "rhel#rhel")
+    Widget-layout format: "scope-./Module" (e.g., "landing-./RhelWidget")
+    """
+    if not isinstance(items, list):
+        return items, set()
+
+    unmapped = set()
+    for item in items:
+        if not isinstance(item, dict) or "i" not in item:
+            continue
+        raw_id = item["i"]
+        # Strip "#suffix" if present (chrome-service uses "key#key" format)
+        short_key = raw_id.split("#")[0]
+        if short_key in WIDGET_ID_MAP:
+            item["i"] = WIDGET_ID_MAP[short_key]
+        else:
+            unmapped.add(raw_id)
+    return items, unmapped
 
 
 def check(label, ok, detail=""):
@@ -285,6 +333,21 @@ def do_export():
         print(f"ERROR: {len(unmapped)} unmapped name values: {unmapped}")
         print("Add these to NAME_MAP before proceeding.")
         sys.exit(1)
+
+    # Transform widget item "i" fields in JSONB columns (sm, md, lg, xl)
+    all_unmapped_ids = set()
+    for row in rows:
+        for col in ("sm", "md", "lg", "xl"):
+            if row[col] is not None:
+                row[col], unmapped = transform_widget_ids(row[col])
+                all_unmapped_ids |= unmapped
+    if all_unmapped_ids:
+        print(f"ERROR: {len(all_unmapped_ids)} unmapped widget IDs in JSONB: {sorted(all_unmapped_ids)}")
+        print("Add these to WIDGET_ID_MAP before proceeding.")
+        cur.close()
+        conn.close()
+        sys.exit(1)
+    print(f"Transformed widget IDs in JSONB columns (sm/md/lg/xl)")
 
     bad_rows = [r for r in rows if not r["user_id"]]
     if bad_rows:

--- a/docs/chrome-data-migration/widget-migration-script.py
+++ b/docs/chrome-data-migration/widget-migration-script.py
@@ -27,6 +27,7 @@ import psycopg2
 import psycopg2.extras
 
 OUTPUT_FILE = "/tmp/widget_migration.sql"
+META_FILE = "/tmp/widget_migration.meta"
 
 # Chrome-service widget IDs -> widget-layout-backend FEO widget IDs.
 # Source: docs/WIDGET_MIGRATION.md
@@ -278,6 +279,23 @@ def do_preflight_import():
     else:
         all_ok &= check(f"SQL file exists ({OUTPUT_FILE})", False, "copy it from source debug-container first")
 
+    # 7. Cross-check against export metadata (catches truncated file transfers)
+    meta_exists = os.path.exists(META_FILE)
+    if meta_exists and sql_exists:
+        with open(META_FILE) as f:
+            for line in f:
+                if line.startswith("INSERT_COUNT="):
+                    expected = int(line.strip().split("=", 1)[1])
+                    match = insert_count == expected
+                    all_ok &= check(
+                        "INSERT count matches export",
+                        match,
+                        f"expected {expected}, got {insert_count} — file may be truncated" if not match else f"{insert_count} matches",
+                    )
+                    break
+    elif sql_exists:
+        check(f"Meta file ({META_FILE})", False, "not found — copy it alongside the SQL file to enable integrity check")
+
     cur.close()
     conn.close()
 
@@ -389,6 +407,11 @@ def do_export():
 
     insert_count = sum(1 for line in open(OUTPUT_FILE) if line.startswith("INSERT"))
     print(f"Generated {insert_count} INSERT statements in {OUTPUT_FILE}")
+
+    with open(META_FILE, "w") as f:
+        f.write(f"INSERT_COUNT={insert_count}\n")
+    print(f"Wrote expected count to {META_FILE}")
+
     print()
     print("Next steps:")
     print(f"  1. Review {OUTPUT_FILE}")
@@ -400,7 +423,7 @@ def do_export():
     conn.close()
 
 
-def do_import():
+def do_import(auto_confirm=False):
     if not os.path.exists(OUTPUT_FILE):
         print(f"ERROR: {OUTPUT_FILE} not found.")
         print("Copy it from the export debug-container first.")
@@ -412,10 +435,13 @@ def do_import():
     insert_count = sql.count("INSERT INTO")
     print(f"Found {insert_count} INSERT statements in {OUTPUT_FILE}")
 
-    confirm = input("Proceed with import? (y/N): ").strip().lower()
-    if confirm != "y":
-        print("Aborted.")
-        return
+    if auto_confirm:
+        print("--yes flag set, skipping confirmation.")
+    else:
+        confirm = input("Proceed with import? (y/N): ").strip().lower()
+        if confirm != "y":
+            print("Aborted.")
+            return
 
     conn = get_connection()
     cur = conn.cursor()
@@ -442,7 +468,8 @@ def do_import():
 
 if __name__ == "__main__":
     commands = ("preflight-export", "preflight-import", "export", "import")
-    if len(sys.argv) != 2 or sys.argv[1] not in commands:
+    cmd = sys.argv[1] if len(sys.argv) >= 2 else None
+    if cmd not in commands:
         print("Usage: python3 widget-migration-script.py <command>")
         print()
         print("  preflight-export  - Run inside chrome-service debug-container")
@@ -454,11 +481,11 @@ if __name__ == "__main__":
         print("  export            - Run inside chrome-service debug-container")
         print("                      Generates SQL file from source DB")
         print()
-        print("  import            - Run inside widget-layout-backend debug-container")
+        print("  import [--yes]    - Run inside widget-layout-backend debug-container")
         print("                      Executes SQL file against target DB")
+        print("                      --yes skips interactive confirmation")
         sys.exit(1)
 
-    cmd = sys.argv[1]
     if cmd == "preflight-export":
         do_preflight_export()
     elif cmd == "preflight-import":
@@ -466,4 +493,5 @@ if __name__ == "__main__":
     elif cmd == "export":
         do_export()
     else:
-        do_import()
+        auto_confirm = "--yes" in sys.argv[2:]
+        do_import(auto_confirm=auto_confirm)

--- a/docs/chrome-data-migration/widget-migration-script.py
+++ b/docs/chrome-data-migration/widget-migration-script.py
@@ -302,7 +302,7 @@ def do_preflight_import():
         if not found_insert_count:
             all_ok &= check("INSERT count matches export", False, "INSERT_COUNT missing in meta file")
     elif sql_exists:
-        check(f"Meta file ({META_FILE})", False, "not found — copy it alongside the SQL file to enable integrity check")
+        all_ok &= check(f"Meta file ({META_FILE})", False, "not found — copy it alongside the SQL file to enable integrity check")
 
     cur.close()
     conn.close()


### PR DESCRIPTION
## Summary
- Add `WIDGET_ID_MAP` (16 entries from `docs/WIDGET_MIGRATION.md`) and `transform_widget_ids()` to the migration script to rewrite widget item `"i"` fields in JSONB columns (`sm`/`md`/`lg`/`xl`) from chrome-service format (`"rhel#rhel"`) to FEO format (`"landing-./RhelWidget"`)
- Without this transformation, the frontend cannot match dashboard template items to widget definitions from the `/widget-mapping` endpoint, causing no widgets to render
- Update both staging and prod migration docs with schema translation notes, expected output, and post-import verification queries

## Test plan
- [x] Tested end-to-end locally: spun up both PostgreSQL databases, seeded chrome-service DB with 4 dashboard templates covering all 16 widget types, ran full migration pipeline (`preflight-export` → `export` → `preflight-import` → `import`), verified all widget IDs transformed correctly and zero old-format IDs remain
- [ ] Re-run staging migration with cleaned target DB using updated script

🤖 Generated with [Claude Code](https://claude.com/claude-code)